### PR TITLE
Version 1 x x

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,19 @@
+### New in 1.0.0 (Release 2015/07/03)
+* New: `EndpointVerificationStrategy.ClusterMembers` - Similar verification as `EndpointVerificationStrategy.Any` but also adds verified cluster members to the `EndpointPool`.
+* New: `IEtcdClient.Statistics`
+	* `GetLeaderStatistics` - Retrieve the statistical information for leader of the etcd cluster
+	* `GetServerStatistics` - Retrieve the statistical information for the server (Which server depends on how the `EndpointPool` was built)
+	* `GetStoreStatistics` - Retrieve the etcd backing store statistics (For which server depends on how the `EndpointPool` was built)
+* Breaking Change: `IEtcdClient.Enqueue` has been moved to `IEtcdClient.Atomic.Enqueue`
+* Breaking Change: `IKeyDataValueConverter` overhaul
+	* `object ReadString(string value)` has been refactored into `T Read<T>(string value)`
+	* `string WriteString(object value)` has been refactored into `string Write<T>(T value)`
+* Change: The following have been annotated with `[Serializable]`
+	* `Endpoint`
+	* `EndpointPool`
+	* `EndpointRoutingStrategy`
+	* `EndpointVerificationStrategy`
+
 ### New in 0.2.1 (Released 2015/05/07)
 * Fixed: `NullReferenceException` thrown when a `WebException` occurs due to a client connection problem.
 

--- a/meta/Draft.nuspec
+++ b/meta/Draft.nuspec
@@ -14,8 +14,8 @@
         <copyright>Copyright 2015 Jordan S. Jones</copyright>
         <dependencies>
             <group targetFramework="net45">
-                <dependency id="Flurl" version="1.0.6" />
-                <dependency id="Flurl.Http" version="0.5.0" />
+                <dependency id="Flurl" version="1.0.8" />
+                <dependency id="Flurl.Http" version="0.6.2" />
                 <dependency id="Newtonsoft.Json" version="6.0.8" />
                 <dependency id="Rx-Core" version="2.2.5" />
                 <dependency id="Rx-Interfaces" version="2.2.5" />

--- a/source/Draft/Constants.Etcd.cs
+++ b/source/Draft/Constants.Etcd.cs
@@ -60,6 +60,12 @@ namespace Draft
 
             public const string Path_Stats = "/v2/stats";
 
+            public const string Path_Stats_Leader = Path_Stats + "/leader";
+
+            public const string Path_Stats_Self = Path_Stats + "/self";
+
+            public const string Path_Stats_Store = Path_Stats + "/store";
+
             public const string Path_Version = "/version";
 
         }

--- a/source/Draft/Converters.cs
+++ b/source/Draft/Converters.cs
@@ -12,24 +12,25 @@ namespace Draft
     public static class Converters
     {
 
+        private static IKeyDataValueConverter _default;
+
         internal static readonly JsonValueConverter JsonConverter = new JsonValueConverter();
 
         internal static readonly StringValueConverter StringConverter = new StringValueConverter();
 
-        static Converters()
-        {
-            Default = Json;
-        }
-
         /// <summary>
         ///     The default converter.
         /// </summary>
-        public static IKeyDataValueConverter Default { get; internal set; }
+        public static IKeyDataValueConverter Default
+        {
+            get { return _default ?? Json; }
+            internal set { _default = value; }
+        }
 
         /// <summary>
         ///     Json based converter.
         /// </summary>
-        public static IJsonKeyDataValueConverter Json
+        public static IKeyDataValueConverter Json
         {
             get { return JsonConverter; }
         }

--- a/source/Draft/Draft-Net45.csproj
+++ b/source/Draft/Draft-Net45.csproj
@@ -78,6 +78,7 @@
     <Compile Include="Endpoints\VerificationStrategy.None.cs" />
     <Compile Include="Endpoints\VerificationStrategy.All.cs" />
     <Compile Include="Endpoints\VerificationStrategy.Any.cs" />
+    <Compile Include="Exceptions\BadRequestException.cs" />
     <Compile Include="Exceptions\ClientInternalException.cs" />
     <Compile Include="Exceptions\DirectoryNotEmptyException.cs" />
     <Compile Include="Exceptions\EtcdException.cs" />
@@ -106,6 +107,7 @@
     <Compile Include="Exceptions\PreviousValueRequiredException.cs" />
     <Compile Include="Exceptions\RaftInternalException.cs" />
     <Compile Include="Exceptions\RootIsReadOnlyException.cs" />
+    <Compile Include="Exceptions\ServiceUnavailableException.cs" />
     <Compile Include="Exceptions\StandbyInternalException.cs" />
     <Compile Include="Exceptions\TestFailedException.cs" />
     <Compile Include="Exceptions\TimeoutNotANumberException.cs" />

--- a/source/Draft/Draft-Net45.csproj
+++ b/source/Draft/Draft-Net45.csproj
@@ -34,17 +34,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Flurl, Version=1.0.7.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Flurl.1.0.7\lib\portable-net40+sl50+win+wpa81+wp80+MonoAndroid10+MonoTouch10\Flurl.dll</HintPath>
+    <Reference Include="Flurl, Version=1.0.8.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Flurl.1.0.8\lib\portable-net40+sl50+win+wpa81+wp80+MonoAndroid10+MonoTouch10\Flurl.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Flurl.Http, Version=0.6.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Flurl.Http.0.6.0\lib\net45\Flurl.Http.dll</HintPath>
+    <Reference Include="Flurl.Http, Version=0.6.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Flurl.Http.0.6.2\lib\net45\Flurl.Http.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -78,6 +78,7 @@
     <Compile Include="Endpoints\VerificationStrategy.None.cs" />
     <Compile Include="Endpoints\VerificationStrategy.All.cs" />
     <Compile Include="Endpoints\VerificationStrategy.Any.cs" />
+    <Compile Include="Endpoints\VerificationStrategy.ClusterMembers.cs" />
     <Compile Include="Exceptions\BadRequestException.cs" />
     <Compile Include="Exceptions\ClientInternalException.cs" />
     <Compile Include="Exceptions\DirectoryNotEmptyException.cs" />
@@ -123,6 +124,7 @@
     <Compile Include="Helpers\FormBodyBuilder.cs" />
     <Compile Include="Helpers\IRandom.cs" />
     <Compile Include="Helpers\StaticRandom.cs" />
+    <Compile Include="Helpers\NormalizedPathSegment.cs" />
     <Compile Include="Json\EtcdErrorCodeConverter.cs" />
     <Compile Include="Requests\Cluster\CreateMemberRequest.cs" />
     <Compile Include="Requests\Cluster\DeleteMemberRequest.cs" />
@@ -136,6 +138,12 @@
     <Compile Include="Requests\Cluster\UpdateMemberPeerUrlsRequest.cs" />
     <Compile Include="Requests\GetVersionRequest.cs" />
     <Compile Include="Requests\IGetVersionRequest.cs" />
+    <Compile Include="Requests\Statistics\GetLeaderStatisticsRequest.cs" />
+    <Compile Include="Requests\Statistics\GetSelfStatisticsRequest.cs" />
+    <Compile Include="Requests\Statistics\GetStoreStatisticsRequest.cs" />
+    <Compile Include="Requests\Statistics\IGetLeaderStatisticsRequest.cs" />
+    <Compile Include="Requests\Statistics\IGetServerStatisticsRequest.cs" />
+    <Compile Include="Requests\Statistics\IGetStoreStatisticsRequest.cs" />
     <Compile Include="Responses\Cluster\ClusterMember.cs" />
     <Compile Include="Responses\Cluster\ClusterMemberCollection.cs" />
     <Compile Include="Responses\Cluster\IClusterMember.cs" />
@@ -145,6 +153,13 @@
     <Compile Include="Responses\IEtcdVersion.cs" />
     <Compile Include="Responses\IHaveAValueConverter.cs" />
     <Compile Include="Responses\IHaveResponseHeaders.cs" />
+    <Compile Include="Responses\Statistics\IFollowerCounts.cs" />
+    <Compile Include="Responses\Statistics\IFollowerLatency.cs" />
+    <Compile Include="Responses\Statistics\IFollowerStatistics.cs" />
+    <Compile Include="Responses\Statistics\ILeaderInfo.cs" />
+    <Compile Include="Responses\Statistics\ILeaderStatistics.cs" />
+    <Compile Include="Responses\Statistics\IServerStatistics.cs" />
+    <Compile Include="Responses\Statistics\IStoreStatistics.cs" />
     <Compile Include="ValueConverters\JsonValueConverter.cs" />
     <Compile Include="ValueConverters\StringValueConverter.cs" />
     <Compile Include="Etcd.cs" />
@@ -199,9 +214,7 @@
     <Compile Include="Constants.ErrorCode.cs" />
     <None Include="packages.Draft-Net45.config" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Requests\Statistics\" />
-  </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/source/Draft/Endpoints/Endpoint.cs
+++ b/source/Draft/Endpoints/Endpoint.cs
@@ -1,13 +1,22 @@
 ﻿using System;
 using System.Linq;
+using System.Runtime.Serialization;
 
 namespace Draft.Endpoints
 {
     /// <summary>
     ///     Represents a verified etcd endpoint.
     /// </summary>
+    [Serializable, DataContract]
     public sealed class Endpoint : IEquatable<Endpoint>
     {
+
+        /// <summary>
+        ///     Initializes a new <see cref="Endpoint" /> class with default values for <see cref="Availability" /> and
+        ///     <see cref="Uri" />.
+        /// </summary>
+        public Endpoint()
+            : this(default(Uri), default(EndpointAvailability)) {}
 
         /// <summary>
         ///     Initializes a new <see cref="Endpoint" /> class with the specified <paramref name="availability" /> and
@@ -24,11 +33,13 @@ namespace Draft.Endpoints
         /// <summary>
         ///     <see cref="EndpointAvailability" /> value of this etcd endpoint.
         /// </summary>
+        [DataMember(Order = 1)]
         public EndpointAvailability Availability { get; private set; }
 
         /// <summary>
         ///     Is <c>true</c> when <see cref="Availability" /><c> == </c><see cref="EndpointAvailability.Online" />.
         /// </summary>
+        [IgnoreDataMember]
         public bool IsOnline
         {
             get { return Availability == EndpointAvailability.Online; }
@@ -37,7 +48,28 @@ namespace Draft.Endpoints
         /// <summary>
         ///     <see cref="Uri" /> value of this etcd endpoint.
         /// </summary>
+        [DataMember(Order = 2)]
         public Uri Uri { get; private set; }
+
+        /// <summary>
+        ///     Creates a new <see cref="Endpoint" /> instance with the specified <paramref name="availability" /> value.
+        /// </summary>
+        /// <returns>A new <see cref="Endpoint" /> instance with the specified <paramref name="availability" /> value.</returns>
+        public Endpoint WithEndpointAvailability(EndpointAvailability availability)
+        {
+            return new Endpoint(Uri, availability);
+        }
+
+        /// <summary>
+        ///     Creates a new <see cref="Endpoint" /> instance with the specified <paramref name="uri" /> value.
+        /// </summary>
+        /// <returns>A new <see cref="Endpoint" /> instance with the specified <paramref name="uri" /> value.</returns>
+        public Endpoint WithUri(Uri uri)
+        {
+            return new Endpoint(uri, Availability);
+        }
+
+        #region Equality
 
         /// <summary>
         ///     Determines whether the specified <see cref="Endpoint" /> is equal to the current <see cref="Endpoint" />.
@@ -46,7 +78,7 @@ namespace Draft.Endpoints
         {
             if (ReferenceEquals(null, other)) { return false; }
             if (ReferenceEquals(this, other)) { return true; }
-            return Availability == other.Availability && Equals(Uri, other.Uri);
+            return Equals(Uri, other.Uri);
         }
 
         /// <summary>
@@ -64,7 +96,7 @@ namespace Draft.Endpoints
         /// </summary>
         public override int GetHashCode()
         {
-            unchecked { return ((int) Availability * 397) ^ (Uri != null ? Uri.GetHashCode() : 0); }
+            unchecked { return (Uri != null ? Uri.GetHashCode() : 0); }
         }
 
         /// <summary>
@@ -83,5 +115,6 @@ namespace Draft.Endpoints
             return !Equals(left, right);
         }
 
+        #endregion
     }
 }

--- a/source/Draft/Endpoints/EndpointRoutingStrategy.cs
+++ b/source/Draft/Endpoints/EndpointRoutingStrategy.cs
@@ -1,14 +1,17 @@
 ﻿using System;
 using System.Linq;
+using System.Runtime.Serialization;
 
 namespace Draft.Endpoints
 {
     /// <summary>
     ///     Represents a strategy for selecting which etcd endpoint to use for http calls.
     /// </summary>
+    [Serializable, DataContract]
     public abstract class EndpointRoutingStrategy
     {
 
+        [IgnoreDataMember]
         internal static EndpointRoutingStrategy Default
         {
             get { return First; }
@@ -24,15 +27,19 @@ namespace Draft.Endpoints
 
         #region Built-in strategies
 
+        [IgnoreDataMember]
         private static readonly Lazy<EndpointRoutingStrategy> LazyFirst = new Lazy<EndpointRoutingStrategy>(() => new RoutingStrategyFirst());
 
+        [IgnoreDataMember]
         private static readonly Lazy<EndpointRoutingStrategy> LazyRandom = new Lazy<EndpointRoutingStrategy>(() => new RoutingStrategyRandom());
 
+        [IgnoreDataMember]
         private static readonly Lazy<EndpointRoutingStrategy> LazyRoundRobin = new Lazy<EndpointRoutingStrategy>(() => new RoutingStrategyRoundRobin());
 
         /// <summary>
         ///     Uses the first <see cref="Endpoint" />.
         /// </summary>
+        [IgnoreDataMember]
         public static EndpointRoutingStrategy First
         {
             get { return LazyFirst.Value; }
@@ -41,6 +48,7 @@ namespace Draft.Endpoints
         /// <summary>
         ///     Uses a randomly selected <see cref="Endpoint" />.
         /// </summary>
+        [IgnoreDataMember]
         public static EndpointRoutingStrategy Random
         {
             get { return LazyRandom.Value; }
@@ -49,6 +57,7 @@ namespace Draft.Endpoints
         /// <summary>
         ///     Uses a round-robin patter for selecting the <see cref="Endpoint" />.
         /// </summary>
+        [IgnoreDataMember]
         public static EndpointRoutingStrategy RoundRobin
         {
             get { return LazyRoundRobin.Value; }

--- a/source/Draft/Endpoints/EndpointVerificationStrategy.cs
+++ b/source/Draft/Endpoints/EndpointVerificationStrategy.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Serialization;
 using System.Threading.Tasks;
 
 using Draft.Exceptions;
@@ -10,9 +11,11 @@ namespace Draft.Endpoints
     /// <summary>
     ///     Represents a strategy for verifying etcd enpoint availability.
     /// </summary>
+    [Serializable, DataContract]
     public abstract class EndpointVerificationStrategy
     {
 
+        [IgnoreDataMember]
         internal static EndpointVerificationStrategy Default
         {
             get { return None; }
@@ -27,15 +30,22 @@ namespace Draft.Endpoints
 
         #region Built-in strategies
 
+        [IgnoreDataMember]
         private static readonly Lazy<EndpointVerificationStrategy> LazyAll = new Lazy<EndpointVerificationStrategy>(() => new VerificationStrategyAll());
 
+        [IgnoreDataMember]
         private static readonly Lazy<EndpointVerificationStrategy> LazyAny = new Lazy<EndpointVerificationStrategy>(() => new VerificationStrategyAny());
 
+        [IgnoreDataMember]
+        private static readonly Lazy<EndpointVerificationStrategy> LazyClusterMembers = new Lazy<EndpointVerificationStrategy>(() => new VerificationStrategyClusterMembers());
+
+        [IgnoreDataMember]
         private static readonly Lazy<EndpointVerificationStrategy> LazyNone = new Lazy<EndpointVerificationStrategy>(() => new VerificationStrategyNone());
 
         /// <summary>
         ///     Verify all supplied endpoints are responding.
         /// </summary>
+        [IgnoreDataMember]
         public static EndpointVerificationStrategy All
         {
             get { return LazyAll.Value; }
@@ -44,14 +54,25 @@ namespace Draft.Endpoints
         /// <summary>
         ///     Verify any supplied endpoints are responding.
         /// </summary>
+        [IgnoreDataMember]
         public static EndpointVerificationStrategy Any
         {
             get { return LazyAny.Value; }
         }
 
         /// <summary>
+        ///     Similar verification as <see cref="Any" /> but also adds verified cluster members to the <see cref="EndpointPool" />.
+        /// </summary>
+        [IgnoreDataMember]
+        public static EndpointVerificationStrategy ClusterMembers
+        {
+            get { return LazyClusterMembers.Value; }
+        }
+
+        /// <summary>
         ///     Doesn't do any endpoint verification.
         /// </summary>
+        [IgnoreDataMember]
         public static EndpointVerificationStrategy None
         {
             get { return LazyNone.Value; }

--- a/source/Draft/Endpoints/RoutingStrategy.First.cs
+++ b/source/Draft/Endpoints/RoutingStrategy.First.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Linq;
+using System.Runtime.Serialization;
 
 namespace Draft.Endpoints
 {
+    [Serializable, DataContract]
     internal sealed class RoutingStrategyFirst : EndpointRoutingStrategy
     {
 

--- a/source/Draft/Endpoints/RoutingStrategy.Random.cs
+++ b/source/Draft/Endpoints/RoutingStrategy.Random.cs
@@ -1,18 +1,27 @@
 ﻿using System;
 using System.Linq;
+using System.Runtime.Serialization;
 
 namespace Draft.Endpoints
 {
+    [Serializable, DataContract]
     internal sealed class RoutingStrategyRandom : EndpointRoutingStrategy
     {
 
-        private readonly IRandom _random;
+        [NonSerialized, IgnoreDataMember]
+        private IRandom _random;
 
         public RoutingStrategyRandom() : this(StaticRandom.Instance) {}
 
         public RoutingStrategyRandom(IRandom random)
         {
             _random = random ?? StaticRandom.Instance;
+        }
+
+        [OnDeserialized]
+        private void OnDeserialized(StreamingContext ignored)
+        {
+            _random = _random ?? StaticRandom.Instance;
         }
 
         public override Endpoint Select(string key, Endpoint[] endpoints)

--- a/source/Draft/Endpoints/RoutingStrategy.RoundRobin.cs
+++ b/source/Draft/Endpoints/RoutingStrategy.RoundRobin.cs
@@ -1,12 +1,15 @@
 ﻿using System;
 using System.Linq;
+using System.Runtime.Serialization;
 using System.Threading;
 
 namespace Draft.Endpoints
 {
+    [Serializable, DataContract]
     internal sealed class RoutingStrategyRoundRobin : EndpointRoutingStrategy
     {
 
+        [DataMember(Order = 1)]
         private int _next = -1;
 
         public override Endpoint Select(string key, Endpoint[] endpoints)

--- a/source/Draft/Endpoints/VerificationStrategy.All.cs
+++ b/source/Draft/Endpoints/VerificationStrategy.All.cs
@@ -1,12 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Serialization;
 using System.Threading.Tasks;
 
 using Draft.Exceptions;
 
 namespace Draft.Endpoints
 {
+    [Serializable, DataContract]
     internal sealed class VerificationStrategyAll : EndpointVerificationStrategy
     {
 

--- a/source/Draft/Endpoints/VerificationStrategy.Any.cs
+++ b/source/Draft/Endpoints/VerificationStrategy.Any.cs
@@ -1,12 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Serialization;
 using System.Threading.Tasks;
 
 using Draft.Exceptions;
 
 namespace Draft.Endpoints
 {
+    [Serializable, DataContract]
     internal sealed class VerificationStrategyAny : EndpointVerificationStrategy
     {
 

--- a/source/Draft/Endpoints/VerificationStrategy.ClusterMembers.cs
+++ b/source/Draft/Endpoints/VerificationStrategy.ClusterMembers.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Threading.Tasks;
+
+using Draft.Exceptions;
+
+namespace Draft.Endpoints
+{
+    [Serializable, DataContract]
+    internal sealed class VerificationStrategyClusterMembers : EndpointVerificationStrategy
+    {
+
+        private async Task<List<Endpoint>> DoVerify(IEnumerable<Uri> uris)
+        {
+            return (await uris.ParallelValidateEndpoints()).ToList();
+        }
+
+        public override async Task<IEnumerable<Endpoint>> Verify(IEnumerable<Uri> endpointUris)
+        {
+            var uris = (endpointUris ?? Enumerable.Empty<Uri>()).ToList();
+            var endpoints = await DoVerify(uris);
+
+            var distinctEndpoints = new HashSet<Endpoint>(endpoints.Where(x => x.IsOnline));
+
+            if (!distinctEndpoints.Any())
+            {
+                throw new InvalidHostException(
+                    string.Format(
+                        "The following endpoints are not responding: {0}",
+                        string.Join(", ", uris.Select(x => x.ToString()))
+                        ));
+            }
+
+            var memberUris = (await distinctEndpoints.Select(x => x.Uri).ParallelLoadClusterMembers()).ToList();
+            var verifiedMemberEndpoints = await DoVerify(memberUris);
+
+            verifiedMemberEndpoints
+                .ForEach(x => distinctEndpoints.Add(x));
+
+            return distinctEndpoints;
+        }
+
+    }
+}

--- a/source/Draft/Endpoints/VerificationStrategy.None.cs
+++ b/source/Draft/Endpoints/VerificationStrategy.None.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Serialization;
 using System.Threading.Tasks;
 
 namespace Draft.Endpoints
 {
+    [Serializable, DataContract]
     internal sealed class VerificationStrategyNone : EndpointVerificationStrategy
     {
 

--- a/source/Draft/EtcdClient.cs
+++ b/source/Draft/EtcdClient.cs
@@ -6,10 +6,11 @@ using Draft.Configuration;
 using Draft.Endpoints;
 using Draft.Requests;
 using Draft.Requests.Cluster;
+using Draft.Requests.Statistics;
 
 namespace Draft
 {
-    internal class EtcdClient : IEtcdClient, IAtomicEtcdClient, IClusterEtcdClient
+    internal class EtcdClient : IEtcdClient, IAtomicEtcdClient, IClusterEtcdClient, IStatisticsEtcdClient
     {
 
         private readonly object _gate = new object();
@@ -27,12 +28,12 @@ namespace Draft
             get { return _clientConfig; }
         }
 
-        public EndpointPool EndpointPool { get; private set; }
-
         IEtcdClientConfig IEtcdClient.Config
         {
             get { return Config; }
         }
+
+        public EndpointPool EndpointPool { get; private set; }
 
         #region Client Config
 
@@ -66,11 +67,6 @@ namespace Draft
         public IDeleteKeyRequest DeleteKey(string key)
         {
             return new DeleteRequest(this, EndpointPool, false, Constants.Etcd.Path_Keys, key);
-        }
-
-        IQueueRequest IEtcdClient.Enqueue(string key)
-        {
-            return Enqueue(key);
         }
 
         public IGetRequest GetKey(string key)
@@ -169,6 +165,30 @@ namespace Draft
         public IUpdateMemberPeerUrlsRequest UpdateMemberPeerUrls()
         {
             return new UpdateMemberPeerUrlsRequest(this, EndpointPool, Constants.Etcd.Path_Members);
+        }
+
+        #endregion
+
+        #region IStatisticsEtcd Client
+
+        public IStatisticsEtcdClient Statistics
+        {
+            get { return this; }
+        }
+
+        public IGetLeaderStatisticsRequest GetLeaderStatistics()
+        {
+            return new GetLeaderStatisticsRequest(this, EndpointPool, Constants.Etcd.Path_Stats_Leader);
+        }
+
+        public IGetServerStatisticsRequest GetServerStatistics()
+        {
+            return new GetSelfStatisticsRequest(this, EndpointPool, Constants.Etcd.Path_Stats_Self);
+        }
+
+        public IGetStoreStatisticsRequest GetStoreStatistics()
+        {
+            return new GetStoreStatisticsRequest(this, EndpointPool, Constants.Etcd.Path_Stats_Store);
         }
 
         #endregion

--- a/source/Draft/Exceptions/BadRequestException.cs
+++ b/source/Draft/Exceptions/BadRequestException.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Linq;
+
+namespace Draft.Exceptions
+{
+    /// <summary>
+    ///     Represents a general problem with the requst to etcd.
+    /// </summary>
+    public class BadRequestException : EtcdException
+    {
+
+        /// <summary>
+        ///     Initializes a new <see cref="BadRequestException" /> instance.
+        /// </summary>
+        public BadRequestException() {}
+
+        /// <summary>
+        ///     Initializes a new <see cref="BadRequestException" /> instance with a specified error message.
+        /// </summary>
+        public BadRequestException(string message) : base(message) {}
+
+        /// <summary>
+        ///     Indicates that this exception is due to a general problem with the request to etcd.
+        /// </summary>
+        public override bool IsBadRequest
+        {
+            get { return true; }
+        }
+
+    }
+}

--- a/source/Draft/Exceptions/EtcdException.cs
+++ b/source/Draft/Exceptions/EtcdException.cs
@@ -36,6 +36,14 @@ namespace Draft.Exceptions
         public HttpStatusCode? HttpStatusCode { get; internal set; }
 
         /// <summary>
+        ///     Indicates that this exception is due to a general problem with the request to etcd.
+        /// </summary>
+        public virtual bool IsBadRequest
+        {
+            get { return false; }
+        }
+
+        /// <summary>
         ///     Indicates that this exception is due to an internal client error
         /// </summary>
         public virtual bool IsClientInternal
@@ -232,6 +240,14 @@ namespace Draft.Exceptions
         /// </summary>
         /// <remarks>You probably tried to set a value on the root keyspace.</remarks>
         public virtual bool IsRootReadOnly
+        {
+            get { return false; }
+        }
+
+        /// <summary>
+        ///     Indicates that this exception is due to an "Service unavailable error".
+        /// </summary>
+        public virtual bool IsServiceUnavailable
         {
             get { return false; }
         }

--- a/source/Draft/Exceptions/ExceptionHandling.cs
+++ b/source/Draft/Exceptions/ExceptionHandling.cs
@@ -39,6 +39,8 @@ namespace Draft
             if (fhe.IsTimeoutException()) { return fhe.AsTimeoutException(); }
             if (fhe.IsInvalidHostException()) { return fhe.AsInvalidHostException(); }
             if (fhe.IsInvalidRequestException()) { return fhe.AsInvalidRequestException(); }
+            if (fhe.IsBadRequestException()) { return fhe.AsBadRequestException(); }
+            if (fhe.IsServiceUnavailableException()) { return fhe.AsServiceUnavailableException(); }
             if (fhe.IsHttpConnectionException()) { return fhe.AsHttpConnectionException(); }
 
             var etcdError = fhe.GetResponseJson<EtcdError>();
@@ -155,6 +157,22 @@ namespace Draft
             return exception;
         }
 
+        #region Bad Request Exception
+
+        private static EtcdException AsBadRequestException(this FlurlHttpException This)
+        {
+            return new BadRequestException(This.Message);
+        }
+
+        private static bool IsBadRequestException(this FlurlHttpException This)
+        {
+            return This.Call.HttpStatus.HasValue
+                   && This.Call.HttpStatus.Value == HttpStatusCode.BadRequest
+                   && !This.Call.Response.IsJsonContentType();
+        }
+
+        #endregion
+
         #region Connection Closed Exception
 
         private static EtcdException AsHttpConnectionException(this FlurlHttpException This)
@@ -189,7 +207,7 @@ namespace Draft
 
         private static EtcdException AsInvalidHostException(this FlurlHttpException This)
         {
-            return new InvalidHostException();
+            return new InvalidHostException(This.Message);
         }
 
         private static bool IsInvalidHostException(this FlurlHttpException This)
@@ -219,6 +237,22 @@ namespace Draft
         }
 
         #endregion
+
+        #region Service Unavailable Exception
+
+        private static EtcdException AsServiceUnavailableException(this FlurlHttpException This)
+        {
+            return new ServiceUnavailableException(This.Message);
+        }
+
+        private static bool IsServiceUnavailableException(this FlurlHttpException This)
+        {
+            return This.Call.HttpStatus.HasValue
+                   && This.Call.HttpStatus.Value == HttpStatusCode.ServiceUnavailable;
+        }
+
+        #endregion
+
 
         #region Timeout Exception
 

--- a/source/Draft/Exceptions/ServiceUnavailableException.cs
+++ b/source/Draft/Exceptions/ServiceUnavailableException.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Linq;
+
+namespace Draft.Exceptions
+{
+    /// <summary>
+    ///     Represents a "Service unavailable error".
+    /// </summary>
+    public class ServiceUnavailableException : EtcdException
+    {
+
+        /// <summary>
+        ///     Initializes a new <see cref="ServiceUnavailableException" /> instance.
+        /// </summary>
+        public ServiceUnavailableException() {}
+
+        /// <summary>
+        ///     Initializes a new <see cref="ServiceUnavailableException" /> instance with a specified error message.
+        /// </summary>
+        public ServiceUnavailableException(string message) : base(message) {}
+
+        /// <summary>
+        ///     Indicates that this exception is due to a general problem with the request to etcd.
+        /// </summary>
+        public override bool IsServiceUnavailable
+        {
+            get { return true; }
+        }
+
+    }
+}

--- a/source/Draft/Extensions/ValueConverter.RequestExtensions.cs
+++ b/source/Draft/Extensions/ValueConverter.RequestExtensions.cs
@@ -15,7 +15,7 @@ namespace Draft
         private static string Convert<T>(IEtcdClientConfig config, T value, IKeyDataValueConverter valueConverter = null)
         {
             valueConverter = valueConverter ?? (config.ValueConverter ?? Etcd.Configuration.ValueConverter);
-            return valueConverter.WriteString(value);
+            return valueConverter.Write(value);
         }
 
         /// <summary>

--- a/source/Draft/Extensions/ValueConverter.ResponseExtensions.cs
+++ b/source/Draft/Extensions/ValueConverter.ResponseExtensions.cs
@@ -28,13 +28,7 @@ namespace Draft
             valueConverter = valueConverter == null && keyData != null ? keyData.ValueConverter() : valueConverter;
 
             valueConverter = valueConverter ?? Etcd.Configuration.ValueConverter;
-            var jsonConverter = valueConverter as IJsonKeyDataValueConverter;
-            if (jsonConverter != null)
-            {
-                return jsonConverter.ReadString<T>(value);
-            }
-
-            return (T) valueConverter.ReadString(value);
+            return valueConverter.Read<T>(value);
         }
 
     }

--- a/source/Draft/Helpers/NormalizedPathSegment.cs
+++ b/source/Draft/Helpers/NormalizedPathSegment.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Linq;
+
+using Flurl;
+
+namespace Draft
+{
+    internal sealed class NormalizedPathSegment
+    {
+
+        public NormalizedPathSegment(params string[] pathParts)
+        {
+            pathParts = pathParts ?? new string[0];
+
+            Value = string.Join("/", pathParts.Select(x => x.TrimStart('/').TrimEnd('/')));
+        }
+
+        public string Value { get; private set; }
+
+
+        public Url ToUrl(Uri uri)
+        {
+            return uri.ToUrl().AppendPathSegment(Value);
+        }
+    }
+}

--- a/source/Draft/IEtcdClient.cs
+++ b/source/Draft/IEtcdClient.cs
@@ -2,8 +2,10 @@
 using System.Linq;
 
 using Draft.Configuration;
+using Draft.Endpoints;
 using Draft.Requests;
 using Draft.Requests.Cluster;
+using Draft.Requests.Statistics;
 
 namespace Draft
 {
@@ -19,7 +21,7 @@ namespace Draft
         IAtomicEtcdClient Atomic { get; }
 
         /// <summary>
-        ///     Returns an etcd cluent for cluster related operations.
+        ///     Returns an etcd client for cluster related operations.
         /// </summary>
         IClusterEtcdClient Cluster { get; }
 
@@ -27,6 +29,11 @@ namespace Draft
         ///     <see cref="IEtcdClient" />'s instance configuration options.
         /// </summary>
         IEtcdClientConfig Config { get; }
+
+        /// <summary>
+        ///     Returns an etcd client for statistics related operations.
+        /// </summary>
+        IStatisticsEtcdClient Statistics { get; }
 
         /// <summary>
         ///     Provides thread-safe access to this instance's configuration options.
@@ -47,15 +54,6 @@ namespace Draft
         ///     Begins a key deletion request.
         /// </summary>
         IDeleteKeyRequest DeleteKey(string key);
-
-        /// <summary>
-        ///     Begins an enqueue key request.
-        /// </summary>
-        /// <remarks>
-        /// <para>This is being moved to live as a member of <see cref="IEtcdClient.Atomic" /> (<see cref="IAtomicEtcdClient.Enqueue" />).</para>
-        /// </remarks>
-        [Obsolete("This is being moved to live under the 'Atomic' member. Soon(TM) this will result in a compile time error.")]
-        IQueueRequest Enqueue(string key);
 
         /// <summary>
         ///     Begins a key retrieval request.
@@ -151,6 +149,31 @@ namespace Draft
         ///     Begins an update member peer urls request.
         /// </summary>
         IUpdateMemberPeerUrlsRequest UpdateMemberPeerUrls();
+
+    }
+
+    /// <summary>
+    ///     Etcd client for statistics related operations.
+    /// </summary>
+    public interface IStatisticsEtcdClient
+    {
+
+        /// <summary>
+        ///     Begins a request to retrieve the statistical information for the leader in an etcd cluster.
+        /// </summary>
+        IGetLeaderStatisticsRequest GetLeaderStatistics();
+
+        /// <summary>
+        ///     Begins a request to retrieve the statistical information for the server.
+        /// </summary>
+        /// <remarks>Which server depends on how the <see cref="EndpointPool" /> was built.</remarks>
+        IGetServerStatisticsRequest GetServerStatistics();
+
+        /// <summary>
+        ///     Begins a request to retrieve the etcd backing store statistics.
+        /// </summary>
+        /// <remarks>For which server depends on how the <see cref="EndpointPool" /> was built.</remarks>
+        IGetStoreStatisticsRequest GetStoreStatistics();
 
     }
 }

--- a/source/Draft/IKeyDataValueConverter.cs
+++ b/source/Draft/IKeyDataValueConverter.cs
@@ -5,6 +5,7 @@ using Draft.Responses;
 
 namespace Draft
 {
+
     /// <summary>
     ///     Converts an <see cref="IKeyData" />'s <code>Value</code> to and from a string.
     /// </summary>
@@ -12,37 +13,20 @@ namespace Draft
     {
 
         /// <summary>
-        ///     Converts from the string representation of the object.
+        ///     Converts from the string representation of the <paramref name="value" />.
         /// </summary>
         /// <param name="value">
         ///     <see cref="IKeyData.RawValue" />
         /// </param>
         /// <returns>The converted result of <paramref name="value" />.</returns>
-        object ReadString(string value);
+        T Read<T>(string value);
 
         /// <summary>
-        ///     Converts to the string representation of the object.
+        ///     Converts to the string representation of the <paramref name="value" />.
         /// </summary>
         /// <param name="value">The object to convert.</param>
         /// <returns>The converted result of <paramref name="value" />.</returns>
-        string WriteString(object value);
-
-    }
-
-    /// <summary>
-    ///     Converts an <see cref="IKeyData" />'s <code>Value</code> to and from a json encoded string.
-    /// </summary>
-    public interface IJsonKeyDataValueConverter : IKeyDataValueConverter
-    {
-
-        /// <summary>
-        ///     Converts from the string representation of the object.
-        /// </summary>
-        /// <param name="value">
-        ///     <see cref="IKeyData.RawValue" />
-        /// </param>
-        /// <returns>The <typeparamref name="T" /> converted result of <paramref name="value" /></returns>
-        T ReadString<T>(string value);
+        string Write<T>(T value);
 
     }
 }

--- a/source/Draft/Requests/Cluster/CreateMemberRequest.cs
+++ b/source/Draft/Requests/Cluster/CreateMemberRequest.cs
@@ -10,8 +10,6 @@ using System.Threading.Tasks;
 using Draft.Endpoints;
 using Draft.Responses.Cluster;
 
-using Flurl;
-
 namespace Draft.Requests.Cluster
 {
     internal class CreateMemberRequest : BaseRequest, ICreateMemberRequest

--- a/source/Draft/Requests/Cluster/DeleteMemberRequest.cs
+++ b/source/Draft/Requests/Cluster/DeleteMemberRequest.cs
@@ -8,8 +8,6 @@ using System.Threading.Tasks;
 
 using Draft.Endpoints;
 
-using Flurl;
-
 namespace Draft.Requests.Cluster
 {
     internal class DeleteMemberRequest : BaseRequest, IDeleteMemberRequest

--- a/source/Draft/Requests/Cluster/GetLeaderRequest.cs
+++ b/source/Draft/Requests/Cluster/GetLeaderRequest.cs
@@ -9,8 +9,6 @@ using System.Threading.Tasks;
 using Draft.Endpoints;
 using Draft.Responses.Cluster;
 
-using Flurl;
-
 namespace Draft.Requests.Cluster
 {
     internal class GetLeaderRequest : BaseRequest, IGetLeaderRequest

--- a/source/Draft/Requests/Cluster/GetLeaderRequest.cs
+++ b/source/Draft/Requests/Cluster/GetLeaderRequest.cs
@@ -14,7 +14,7 @@ namespace Draft.Requests.Cluster
     internal class GetLeaderRequest : BaseRequest, IGetLeaderRequest
     {
 
-        public GetLeaderRequest(IEtcdClient etcdClient, EndpointPool endpointPool, params string[] pathParts) 
+        public GetLeaderRequest(IEtcdClient etcdClient, EndpointPool endpointPool, params string[] pathParts)
             : base(etcdClient, endpointPool, pathParts) {}
 
         public async Task<IClusterMember> Execute()

--- a/source/Draft/Requests/Cluster/GetMembersRequest.cs
+++ b/source/Draft/Requests/Cluster/GetMembersRequest.cs
@@ -1,13 +1,13 @@
 ﻿using System;
+
+using Flurl.Http;
+
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
 using Draft.Endpoints;
 using Draft.Responses.Cluster;
-
-using Flurl;
-using Flurl.Http;
 
 namespace Draft.Requests.Cluster
 {

--- a/source/Draft/Requests/Cluster/GetMembersRequest.cs
+++ b/source/Draft/Requests/Cluster/GetMembersRequest.cs
@@ -14,7 +14,7 @@ namespace Draft.Requests.Cluster
     internal class GetMembersRequest : BaseRequest, IGetMembersRequest
     {
 
-        public GetMembersRequest(IEtcdClient etcdClient, EndpointPool endpointPool, params string[] pathParts) 
+        public GetMembersRequest(IEtcdClient etcdClient, EndpointPool endpointPool, params string[] pathParts)
             : base(etcdClient, endpointPool, pathParts) {}
 
         public async Task<IClusterMember[]> Execute()

--- a/source/Draft/Requests/Cluster/UpdateMemberPeerUrlsRequest.cs
+++ b/source/Draft/Requests/Cluster/UpdateMemberPeerUrlsRequest.cs
@@ -35,7 +35,7 @@ namespace Draft.Requests.Cluster
             {
                 return await TargetUrl
                     .AppendPathSegment(MemberId)
-                    .PostJsonAsync(values)
+                    .PutJsonAsync(values)
                     .ReceiveJson<ClusterMember>();
             }
             catch (FlurlHttpException e)

--- a/source/Draft/Requests/Statistics/GetLeaderStatisticsRequest.cs
+++ b/source/Draft/Requests/Statistics/GetLeaderStatisticsRequest.cs
@@ -1,0 +1,39 @@
+﻿using System;
+
+using Flurl.Http;
+
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+using Draft.Endpoints;
+using Draft.Responses.Statistics;
+
+namespace Draft.Requests.Statistics
+{
+    internal class GetLeaderStatisticsRequest : BaseRequest, IGetLeaderStatisticsRequest
+    {
+
+        public GetLeaderStatisticsRequest(IEtcdClient etcdClient, EndpointPool endpointPool, params string[] pathParts) : base(etcdClient, endpointPool, pathParts) {}
+
+        public async Task<ILeaderStatistics> Execute()
+        {
+            try
+            {
+                return await TargetUrl
+                    .GetAsync()
+                    .ReceiveJson<LeaderStatistics>();
+            }
+            catch (FlurlHttpException e)
+            {
+                throw e.ProcessException();
+            }
+        }
+
+        public TaskAwaiter<ILeaderStatistics> GetAwaiter()
+        {
+            return Execute().GetAwaiter();
+        }
+
+    }
+}

--- a/source/Draft/Requests/Statistics/GetSelfStatisticsRequest.cs
+++ b/source/Draft/Requests/Statistics/GetSelfStatisticsRequest.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+using Draft.Endpoints;
+using Draft.Responses.Statistics;
+
+using Flurl.Http;
+
+namespace Draft.Requests.Statistics
+{
+    internal class GetSelfStatisticsRequest : BaseRequest, IGetServerStatisticsRequest
+    {
+
+        public GetSelfStatisticsRequest(IEtcdClient etcdClient, EndpointPool endpointPool, params string[] pathParts) : base(etcdClient, endpointPool, pathParts) {}
+
+        public async Task<IServerStatistics> Execute()
+        {
+            try
+            {
+                return await TargetUrl
+                    .GetAsync()
+                    .ReceiveJson<ServerStatistics>();
+            }
+            catch (FlurlHttpException e)
+            {
+                throw e.ProcessException();
+            }
+        }
+
+        public TaskAwaiter<IServerStatistics> GetAwaiter()
+        {
+            return Execute().GetAwaiter();
+        }
+
+    }
+}

--- a/source/Draft/Requests/Statistics/GetStoreStatisticsRequest.cs
+++ b/source/Draft/Requests/Statistics/GetStoreStatisticsRequest.cs
@@ -1,0 +1,39 @@
+﻿using System;
+
+using Flurl.Http;
+
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+using Draft.Endpoints;
+using Draft.Responses.Statistics;
+
+namespace Draft.Requests.Statistics
+{
+    internal class GetStoreStatisticsRequest : BaseRequest, IGetStoreStatisticsRequest
+    {
+
+        public GetStoreStatisticsRequest(IEtcdClient etcdClient, EndpointPool endpointPool, params string[] pathParts) : base(etcdClient, endpointPool, pathParts) {}
+
+        public async Task<IStoreStatistics> Execute()
+        {
+            try
+            {
+                return await TargetUrl
+                    .GetAsync()
+                    .ReceiveJson<StoreStatistics>();
+            }
+            catch (FlurlHttpException e)
+            {
+                throw e.ProcessException();
+            }
+        }
+
+        public TaskAwaiter<IStoreStatistics> GetAwaiter()
+        {
+            return Execute().GetAwaiter();
+        }
+
+    }
+}

--- a/source/Draft/Requests/Statistics/IGetLeaderStatisticsRequest.cs
+++ b/source/Draft/Requests/Statistics/IGetLeaderStatisticsRequest.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+using Draft.Responses.Statistics;
+
+namespace Draft.Requests.Statistics
+{
+    /// <summary>
+    ///     A request to retrieve the statistical information for the leader in an etcd cluster.
+    /// </summary>
+    public interface IGetLeaderStatisticsRequest
+    {
+
+        /// <summary>
+        ///     The underlying <see cref="IEtcdClient" /> for this request.
+        /// </summary>
+        IEtcdClient EtcdClient { get; }
+
+        /// <summary>
+        ///     Execute this request.
+        /// </summary>
+        Task<ILeaderStatistics> Execute();
+
+        /// <summary>
+        ///     Allows use of the <c>await</c> keyword for this request.
+        /// </summary>
+        TaskAwaiter<ILeaderStatistics> GetAwaiter();
+
+    }
+}

--- a/source/Draft/Requests/Statistics/IGetServerStatisticsRequest.cs
+++ b/source/Draft/Requests/Statistics/IGetServerStatisticsRequest.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+using Draft.Endpoints;
+using Draft.Responses.Statistics;
+
+namespace Draft.Requests.Statistics
+{
+    /// <summary>
+    ///     A request to retrieve the statistical information for the server.
+    /// </summary>
+    /// <remarks>Which server depends on how the <see cref="EndpointPool" /> was built.</remarks>
+    public interface IGetServerStatisticsRequest
+    {
+
+        /// <summary>
+        ///     The underlying <see cref="IEtcdClient" /> for this request.
+        /// </summary>
+        IEtcdClient EtcdClient { get; }
+
+        /// <summary>
+        ///     Execute this request.
+        /// </summary>
+        Task<IServerStatistics> Execute();
+
+        /// <summary>
+        ///     Allows use of the <c>await</c> keyword for this request.
+        /// </summary>
+        TaskAwaiter<IServerStatistics> GetAwaiter();
+
+    }
+}

--- a/source/Draft/Requests/Statistics/IGetStoreStatisticsRequest.cs
+++ b/source/Draft/Requests/Statistics/IGetStoreStatisticsRequest.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+using Draft.Endpoints;
+using Draft.Responses.Statistics;
+
+namespace Draft.Requests.Statistics
+{
+    /// <summary>
+    ///     A request to retrieve the etcd backing store statistics.
+    /// </summary>
+    /// <remarks>For which server depends on how the <see cref="EndpointPool" /> was built.</remarks>
+    public interface IGetStoreStatisticsRequest
+    {
+
+        /// <summary>
+        ///     The underlying <see cref="IEtcdClient" /> for this request.
+        /// </summary>
+        IEtcdClient EtcdClient { get; }
+
+        /// <summary>
+        ///     Execute this request.
+        /// </summary>
+        Task<IStoreStatistics> Execute();
+
+        /// <summary>
+        ///     Allows use of the <c>await</c> keyword for this request.
+        /// </summary>
+        TaskAwaiter<IStoreStatistics> GetAwaiter();
+
+    }
+}

--- a/source/Draft/Responses/Statistics/FollowerStatistics.cs
+++ b/source/Draft/Responses/Statistics/FollowerStatistics.cs
@@ -8,20 +8,31 @@ namespace Draft.Responses.Statistics
     ///     Various statistics about a follower in an etcd cluster
     /// </summary>
     [DataContract]
-    internal class FollowerStatistics
+    internal class FollowerStatistics : IFollowerStatistics
     {
+
+        IFollowerCounts IFollowerStatistics.Counts
+        {
+            get { return Counts; }
+        }
 
         /// <summary>
         ///     Follower send counts
         /// </summary>
         [DataMember(Name = "counts")]
-        public FollowerCounts Counts { get; private set; }
+        public FollowerCounts Counts { get; set; }
+
+        IFollowerLatency IFollowerStatistics.Latency
+        {
+            get { return Latency; }
+        }
 
         /// <summary>
         ///     Follower latency statistics
         /// </summary>
         [DataMember(Name = "latency")]
-        public FollowerLatency Latency { get; private set; }
+        public FollowerLatency Latency { get; set; }
 
     }
+
 }

--- a/source/Draft/Responses/Statistics/IFollowerCounts.cs
+++ b/source/Draft/Responses/Statistics/IFollowerCounts.cs
@@ -1,27 +1,23 @@
 ﻿using System;
 using System.Linq;
-using System.Runtime.Serialization;
 
 namespace Draft.Responses.Statistics
 {
     /// <summary>
     ///     Follower send counts
     /// </summary>
-    [DataContract]
-    internal class FollowerCounts : IFollowerCounts
+    public interface IFollowerCounts
     {
 
         /// <summary>
         ///     Count of unsuccessful sends
         /// </summary>
-        [DataMember(Name = "fail")]
-        public long Fail { get; set; }
+        long Fail { get; }
 
         /// <summary>
         ///     Count of successful sends
         /// </summary>
-        [DataMember(Name = "success")]
-        public long Success { get; set; }
+        long Success { get; }
 
     }
 }

--- a/source/Draft/Responses/Statistics/IFollowerLatency.cs
+++ b/source/Draft/Responses/Statistics/IFollowerLatency.cs
@@ -1,45 +1,38 @@
 ﻿using System;
 using System.Linq;
-using System.Runtime.Serialization;
 
 namespace Draft.Responses.Statistics
 {
     /// <summary>
     ///     Follower latency statistics
     /// </summary>
-    [DataContract]
-    internal class FollowerLatency : IFollowerLatency
+    public interface IFollowerLatency
     {
 
         /// <summary>
         ///     Follower's average latency
         /// </summary>
-        [DataMember(Name = "average")]
-        public double Average { get; set; }
+        double Average { get; }
 
         /// <summary>
         ///     Follower's current latency
         /// </summary>
-        [DataMember(Name = "current")]
-        public double Current { get; set; }
+        double Current { get; }
 
         /// <summary>
         ///     Follower's maximum latency
         /// </summary>
-        [DataMember(Name = "maximum")]
-        public double Maximum { get; set; }
+        double Maximum { get; }
 
         /// <summary>
         ///     Follower's minimum latency
         /// </summary>
-        [DataMember(Name = "minimum")]
-        public double Minimum { get; set; }
+        double Minimum { get; }
 
         /// <summary>
         ///     Standard Deviation
         /// </summary>
-        [DataMember(Name = "standardDeviation")]
-        public double StandardDeviation { get; set; }
+        double StandardDeviation { get; }
 
     }
 }

--- a/source/Draft/Responses/Statistics/IFollowerStatistics.cs
+++ b/source/Draft/Responses/Statistics/IFollowerStatistics.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Linq;
+
+namespace Draft.Responses.Statistics
+{
+    /// <summary>
+    ///     Various statistics about a follower in an etcd cluster
+    /// </summary>
+    public interface IFollowerStatistics
+    {
+
+        /// <summary>
+        ///     Follower send counts
+        /// </summary>
+        IFollowerCounts Counts { get; }
+
+        /// <summary>
+        ///     Follower latency statistics
+        /// </summary>
+        IFollowerLatency Latency { get; }
+
+    }
+}

--- a/source/Draft/Responses/Statistics/ILeaderInfo.cs
+++ b/source/Draft/Responses/Statistics/ILeaderInfo.cs
@@ -1,34 +1,28 @@
 ﻿using System;
 using System.Linq;
-using System.Runtime.Serialization;
 
 namespace Draft.Responses.Statistics
 {
     /// <summary>
     ///     Statistical information for a member server's leader
     /// </summary>
-    [DataContract]
-    internal class LeaderInfo : ILeaderInfo
+    public interface ILeaderInfo
     {
 
         /// <summary>
         ///     Id of the current leader
         /// </summary>
-        [DataMember(Name = "leader")]
-        public string Leader { get; set; }
+        string Leader { get; }
 
         /// <summary>
         ///     Time when the leader was started (if available)
         /// </summary>
-        [DataMember(Name = "startTime")]
-        public DateTime? StartTime { get; set; }
+        DateTime? StartTime { get; }
 
         /// <summary>
         ///     String representation of the amount of time the leader has been leader
         /// </summary>
-        [DataMember(Name = "uptime")]
-        public string Uptime { get; set; }
+        string Uptime { get; }
 
     }
-
 }

--- a/source/Draft/Responses/Statistics/ILeaderStatistics.cs
+++ b/source/Draft/Responses/Statistics/ILeaderStatistics.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Draft.Responses.Statistics
+{
+    /// <summary>
+    ///     Statistics about communication with cluster members
+    /// </summary>
+    public interface ILeaderStatistics
+    {
+
+        /// <summary>
+        ///     Map of cluster member id's to cluster member statistics
+        /// </summary>
+        IReadOnlyDictionary<string, IFollowerStatistics> Followers { get; }
+
+        /// <summary>
+        ///     Id for the currently elected cluster leader
+        /// </summary>
+        string Leader { get; }
+
+    }
+}

--- a/source/Draft/Responses/Statistics/IServerStatistics.cs
+++ b/source/Draft/Responses/Statistics/IServerStatistics.cs
@@ -1,63 +1,48 @@
 ﻿using System;
 using System.Linq;
-using System.Runtime.Serialization;
 
 namespace Draft.Responses.Statistics
 {
     /// <summary>
     ///     Statistical information on an etcd server member
     /// </summary>
-    [DataContract]
-    internal class ServerStatistics : IServerStatistics
+    public interface IServerStatistics
     {
 
         /// <summary>
         ///     The unique identifier for this server member
         /// </summary>
-        [DataMember(Name = "id")]
-        public string Id { get; set; }
+        string Id { get; }
 
         /// <summary>
         ///     Statistical information for this server member's leader
         /// </summary>
-        [DataMember(Name = "leaderInfo")]
-        public LeaderInfo LeaderInfo { get; set; }
-
-        [IgnoreDataMember]
-        ILeaderInfo IServerStatistics.LeaderInfo
-        {
-            get { return LeaderInfo; }
-        }
+        ILeaderInfo LeaderInfo { get; }
 
         /// <summary>
         ///     The name for this server member
         /// </summary>
-        [DataMember(Name = "name")]
-        public string Name { get; set; }
+        string Name { get; }
 
         /// <summary>
         ///     Number of append requests this server member has processed
         /// </summary>
-        [DataMember(Name = "recvAppendRequestCnt")]
-        public long ReceivedAppendRequestCount { get; set; }
+        long ReceivedAppendRequestCount { get; }
 
         /// <summary>
         ///     Number of bytes per second this server member is receiving (follower state only)
         /// </summary>
-        [DataMember(Name = "recvBandwidthRate")]
-        public double? ReceivedBandwidthRate { get; set; }
+        double? ReceivedBandwidthRate { get; }
 
         /// <summary>
         ///     Number of requests per second this server member is receiving (follower state only)
         /// </summary>
-        [DataMember(Name = "recvPkgRate")]
-        public double? ReceivedPackageRate { get; set; }
+        double? ReceivedPackageRate { get; }
 
         /// <summary>
         ///     Numer of requests this server member has sent
         /// </summary>
-        [DataMember(Name = "sendAppendRequestCnt")]
-        public long SendAppendRequestCount { get; set; }
+        long SendAppendRequestCount { get; }
 
         /// <summary>
         ///     Number of bytes per second this server member is sending (leader state only)
@@ -65,8 +50,7 @@ namespace Draft.Responses.Statistics
         /// <remarks>
         ///     This value is null on single member clusters
         /// </remarks>
-        [DataMember(Name = "sendBandwidthRate")]
-        public double? SendBandwidthRate { get; set; }
+        double? SendBandwidthRate { get; }
 
         /// <summary>
         ///     Number of requests per second this server member is sending (leader state only)
@@ -74,20 +58,17 @@ namespace Draft.Responses.Statistics
         /// <remarks>
         ///     This value is null on single member clusters
         /// </remarks>
-        [DataMember(Name = "sendPkgRate")]
-        public double? SendPackageRate { get; set; }
+        double? SendPackageRate { get; }
 
         /// <summary>
         ///     The time when this server member was started
         /// </summary>
-        [DataMember(Name = "startTime")]
-        public DateTime StartTime { get; set; }
+        DateTime StartTime { get; }
 
         /// <summary>
         ///     The cluster state for this server member
         /// </summary>
-        [DataMember(Name = "state")]
-        public StateType State { get; set; }
+        StateType State { get; }
 
     }
 }

--- a/source/Draft/Responses/Statistics/IStoreStatistics.cs
+++ b/source/Draft/Responses/Statistics/IStoreStatistics.cs
@@ -1,111 +1,93 @@
 ﻿using System;
 using System.Linq;
-using System.Runtime.Serialization;
 
 namespace Draft.Responses.Statistics
 {
     /// <summary>
     ///     Etcd backing store statistics
     /// </summary>
-    [DataContract]
-    internal class StoreStatistics : IStoreStatistics
+    public interface IStoreStatistics
     {
 
         /// <summary>
         ///     Number of failed Compare and Delete requests
         /// </summary>
-        [DataMember(Name = "compareAndDeleteFail")]
-        public long CompareAndDeleteFail { get; private set; }
+        long CompareAndDeleteFail { get; }
 
         /// <summary>
         ///     Number of successful Compare and Delete requests
         /// </summary>
-        [DataMember(Name = "compareAndDeleteSuccess")]
-        public long CompareAndDeleteSuccess { get; private set; }
+        long CompareAndDeleteSuccess { get; }
 
         /// <summary>
         ///     Number of failed Compare and Swap requests
         /// </summary>
-        [DataMember(Name = "compareAndSwapFail")]
-        public long CompareAndSwapFail { get; private set; }
+        long CompareAndSwapFail { get; }
 
         /// <summary>
         ///     Number of successful Compare and Swap requests
         /// </summary>
-        [DataMember(Name = "compareAndSwapSuccess")]
-        public long CompareAndSwapSuccess { get; private set; }
+        long CompareAndSwapSuccess { get; }
 
         /// <summary>
         ///     Number of failed Create requests
         /// </summary>
-        [DataMember(Name = "createFail")]
-        public long CreateFail { get; private set; }
+        long CreateFail { get; }
 
         /// <summary>
         ///     Number of successful Create requests
         /// </summary>
-        [DataMember(Name = "createSuccess")]
-        public long CreateSuccess { get; private set; }
+        long CreateSuccess { get; }
 
         /// <summary>
         ///     Number of failed Delete requests
         /// </summary>
-        [DataMember(Name = "deleteFail")]
-        public long DeleteFail { get; private set; }
+        long DeleteFail { get; }
 
         /// <summary>
         ///     Number of successful Delete requests
         /// </summary>
-        [DataMember(Name = "deleteSuccess")]
-        public long DeleteSuccess { get; private set; }
+        long DeleteSuccess { get; }
 
         /// <summary>
         ///     Number of key expirations
         /// </summary>
-        [DataMember(Name = "expireCount")]
-        public long ExpireCount { get; private set; }
+        long ExpireCount { get; }
 
         /// <summary>
         ///     Number of failed Get requests
         /// </summary>
-        [DataMember(Name = "getsFail")]
-        public long GetsFail { get; private set; }
+        long GetsFail { get; }
 
         /// <summary>
         ///     Number of successful Get requests
         /// </summary>
-        [DataMember(Name = "getsSuccess")]
-        public long GetsSuccess { get; private set; }
+        long GetsSuccess { get; }
 
         /// <summary>
         ///     Number of failed Set requests
         /// </summary>
-        [DataMember(Name = "setsFail")]
-        public long SetsFail { get; private set; }
+        long SetsFail { get; }
 
         /// <summary>
         ///     Number of successful Set requests
         /// </summary>
-        [DataMember(Name = "setsSuccess")]
-        public long SetsSuccess { get; private set; }
+        long SetsSuccess { get; }
 
         /// <summary>
         ///     Number of failed Update requests
         /// </summary>
-        [DataMember(Name = "updateFail")]
-        public long UpdateFail { get; private set; }
+        long UpdateFail { get; }
 
         /// <summary>
         ///     Number of successful Update requests
         /// </summary>
-        [DataMember(Name = "updateSuccess")]
-        public long UpdateSuccess { get; private set; }
+        long UpdateSuccess { get; }
 
         /// <summary>
         ///     Number of active watchers
         /// </summary>
-        [DataMember(Name = "watchers")]
-        public long Watchers { get; private set; }
+        long Watchers { get; }
 
     }
 }

--- a/source/Draft/Responses/Statistics/LeaderStatistics.cs
+++ b/source/Draft/Responses/Statistics/LeaderStatistics.cs
@@ -6,21 +6,36 @@ using System.Runtime.Serialization;
 namespace Draft.Responses.Statistics
 {
     /// <summary>
-    /// Statistics about communication with cluster members
+    ///     Statistics about communication with cluster members
     /// </summary>
     [DataContract]
-    internal class LeaderStatistics
+    internal class LeaderStatistics : ILeaderStatistics
     {
+
+        [DataMember(Name = "followers")]
+        private Dictionary<string, FollowerStatistics> _followers;
+
         /// <summary>
-        /// Id for the currently elected cluster leader
+        ///     Map of cluster member id's to cluster member statistics
+        /// </summary>
+        [IgnoreDataMember]
+        public Dictionary<string, FollowerStatistics> Followers
+        {
+            get { return _followers ?? (_followers = new Dictionary<string, FollowerStatistics>()); }
+        }
+
+        [IgnoreDataMember]
+        IReadOnlyDictionary<string, IFollowerStatistics> ILeaderStatistics.Followers
+        {
+            get { return Followers.ToDictionary(x => x.Key, x => x.Value as IFollowerStatistics); }
+        }
+
+        /// <summary>
+        ///     Id for the currently elected cluster leader
         /// </summary>
         [DataMember(Name = "leader")]
-        public string Leader { get; private set; }
-        
-        /// <summary>
-        /// Map of cluster member id's to cluster member statistics
-        /// </summary>
-        [DataMember(Name = "followers")]
-        public IReadOnlyDictionary<string, FollowerStatistics> Followers { get; private set; }
+        public string Leader { get; set; }
+
     }
+
 }

--- a/source/Draft/Responses/Statistics/StateType.cs
+++ b/source/Draft/Responses/Statistics/StateType.cs
@@ -1,33 +1,38 @@
 ﻿using System;
 using System.Linq;
+using System.Runtime.Serialization;
 
 namespace Draft.Responses.Statistics
 {
     /// <summary>
-    /// Represents the leadership type of a member of a cluster
+    ///     Represents the leadership type of a member of a cluster
     /// </summary>
-    internal enum StateType
+    [DataContract]
+    public enum StateType
     {
 
         /// <summary>
-        /// Unable to parse
+        ///     Unable to parse
         /// </summary>
         Unknown,
 
         /// <summary>
-        /// StateFollower
+        ///     StateFollower
         /// </summary>
-        Follower,
+        [EnumMember(Value = "StateFollower")]
+        StateFollower,
 
         /// <summary>
-        /// StateCandidate
+        ///     StateCandidate
         /// </summary>
-        Candidate,
+        [EnumMember(Value = "StateCandidate")]
+        StateCandidate,
 
         /// <summary>
-        /// StateLeader
+        ///     StateLeader
         /// </summary>
-        Leader
+        [EnumMember(Value = "StateLeader")]
+        StateLeader
 
     }
 }

--- a/source/Draft/ValueConverters/JsonValueConverter.cs
+++ b/source/Draft/ValueConverters/JsonValueConverter.cs
@@ -1,26 +1,23 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace Draft.ValueConverters
 {
-    internal class JsonValueConverter : IJsonKeyDataValueConverter
+    internal class JsonValueConverter : IKeyDataValueConverter
     {
 
-        public T ReadString<T>(string value)
+        public T Read<T>(string value)
         {
-            return JsonConvert.DeserializeObject<T>(value);
+            return JsonConvert.DeserializeObject<T>(value, Etcd.JsonSettings);
         }
 
-        public object ReadString(string value)
+        public string Write<T>(T value)
         {
-            return ReadString<object>(value);
-        }
-
-        public string WriteString(object value)
-        {
-            return JsonConvert.SerializeObject(value);
+            return JsonConvert.SerializeObject(value, Etcd.JsonSettings);
         }
 
     }

--- a/source/Draft/ValueConverters/StringValueConverter.cs
+++ b/source/Draft/ValueConverters/StringValueConverter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Linq;
 
 namespace Draft.ValueConverters
@@ -6,10 +7,65 @@ namespace Draft.ValueConverters
     internal class StringValueConverter : IKeyDataValueConverter
     {
 
+        private static readonly Type StringType = typeof (string);
+
+        public T Read<T>(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return default(T);
+            }
+
+            var tType = typeof (T);
+
+            if (tType.IsEnum)
+            {
+                return (T) Enum.Parse(tType, value, true);
+            }
+
+            var converter = TypeDescriptor.GetConverter(StringType);
+            if (converter.CanConvertTo(tType))
+            {
+                return (T) converter.ConvertTo(value, tType);
+            }
+
+            converter = TypeDescriptor.GetConverter(tType);
+            if (converter.CanConvertFrom(StringType))
+            {
+                return (T) converter.ConvertFromString(value);
+            }
+
+            return (T) Convert.ChangeType(value, tType);
+        }
+
+        public string Write<T>(T value)
+        {
+            if (value == null) { return string.Empty; }
+
+            if (value is Enum)
+            {
+                return Enum.GetName(value.GetType(), value);
+            }
+
+            var tType = typeof (T);
+            var converter = TypeDescriptor.GetConverter(tType);
+            if (converter.CanConvertTo(StringType))
+            {
+                return converter.ConvertToString(value);
+            }
+
+            converter = TypeDescriptor.GetConverter(StringType);
+            if (converter.CanConvertFrom(tType))
+            {
+                return converter.ConvertToString(value);
+            }
+
+            return (string) Convert.ChangeType(value, StringType);
+        }
 
         public object ReadString(string value)
         {
-            return value;
+            return Read<object>(value);
         }
 
         public string WriteString(object value)
@@ -18,7 +74,7 @@ namespace Draft.ValueConverters
             if (strValue != null) { return strValue; }
 
 
-            return Convert.ToString(value);
+            return Write(value);
         }
 
     }

--- a/source/Draft/packages.Draft-Net45.config
+++ b/source/Draft/packages.Draft-Net45.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Flurl" version="1.0.7" targetFramework="net45" />
-  <package id="Flurl.Http" version="0.6.0" targetFramework="net45" />
+  <package id="Flurl" version="1.0.8" targetFramework="net45" />
+  <package id="Flurl.Http" version="0.6.2" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="net45" />

--- a/tests/Draft.Tests/Draft-Net45.Tests.csproj
+++ b/tests/Draft.Tests/Draft-Net45.Tests.csproj
@@ -37,26 +37,28 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FluentAssertions">
-      <HintPath>..\..\packages\FluentAssertions.3.3.0\lib\net45\FluentAssertions.dll</HintPath>
-    </Reference>
-    <Reference Include="FluentAssertions.Core">
-      <HintPath>..\..\packages\FluentAssertions.3.3.0\lib\net45\FluentAssertions.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="Flurl, Version=1.0.7.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Flurl.1.0.7\lib\portable-net40+sl50+win+wpa81+wp80+MonoAndroid10+MonoTouch10\Flurl.dll</HintPath>
+    <Reference Include="FluentAssertions, Version=3.4.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FluentAssertions.3.4.1\lib\net45\FluentAssertions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Flurl.Http, Version=0.6.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Flurl.Http.0.6.0\lib\net45\Flurl.Http.dll</HintPath>
+    <Reference Include="FluentAssertions.Core, Version=3.4.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FluentAssertions.3.4.1\lib\net45\FluentAssertions.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Flurl, Version=1.0.8.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Flurl.1.0.8\lib\portable-net40+sl50+win+wpa81+wp80+MonoAndroid10+MonoTouch10\Flurl.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Flurl.Http, Version=0.6.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Flurl.Http.0.6.2\lib\net45\Flurl.Http.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Ploeh.AutoFixture, Version=3.30.3.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\AutoFixture.3.30.3\lib\net40\Ploeh.AutoFixture.dll</HintPath>
+    <Reference Include="Ploeh.AutoFixture, Version=3.30.8.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\AutoFixture.3.30.8\lib\net40\Ploeh.AutoFixture.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -97,6 +99,7 @@
     <Compile Include="Extensions\HttpTestExtensions.cs" />
     <Compile Include="Fixtures\Dtos\SimpleDataContractDto.cs" />
     <Compile Include="Fixtures\Fixtures.Cluster.cs" />
+    <Compile Include="Fixtures\Fixtures.Statistics.cs" />
     <Compile Include="Fixtures\TestingHttpClientFactory.cs" />
     <Compile Include="Helpers\XmlValueConverter.cs" />
     <Compile Include="Tests\Atomics\CompareAndDeleteTests.cs" />
@@ -129,6 +132,9 @@
     <Compile Include="Tests\RoutingStrategies\RoutingStrategyFirstTests.cs" />
     <Compile Include="Tests\RoutingStrategies\RoutingStrategyRandomTests.cs" />
     <Compile Include="Tests\RoutingStrategies\RoutingStrategyRoundRobinTests.cs" />
+    <Compile Include="Tests\Statistics\GetLeaderTests.cs" />
+    <Compile Include="Tests\Statistics\GetSelfTests.cs" />
+    <Compile Include="Tests\Statistics\GetStoreTests.cs" />
     <Compile Include="Tests\ValueConverterTests.cs" />
     <Compile Include="Tests\VerificationStrategies\BaseVerificationStrategyTests.cs" />
     <Compile Include="Tests\VerificationStrategies\VerificationStrategyAllTests.cs" />

--- a/tests/Draft.Tests/Draft-Net45.Tests.csproj
+++ b/tests/Draft.Tests/Draft-Net45.Tests.csproj
@@ -102,6 +102,10 @@
     <Compile Include="Tests\Atomics\CompareAndDeleteTests.cs" />
     <Compile Include="Tests\Atomics\CompareAndSwapTests.cs" />
     <Compile Include="Tests\Cluster\CreateMemberTests.cs" />
+    <Compile Include="Tests\Cluster\DeleteMemberTests.cs" />
+    <Compile Include="Tests\Cluster\GetLeaderTests.cs" />
+    <Compile Include="Tests\Cluster\GetMembersTests.cs" />
+    <Compile Include="Tests\Cluster\UpdateMemberPeerUrlsTests.cs" />
     <Compile Include="Tests\ConfigureTests.cs" />
     <Compile Include="Tests\Exceptions\CoreExceptionTests.cs" />
     <Compile Include="Tests\Keys\DirectoryRequestTests.cs" />

--- a/tests/Draft.Tests/Fixtures/Fixtures.Cluster.cs
+++ b/tests/Draft.Tests/Fixtures/Fixtures.Cluster.cs
@@ -18,6 +18,25 @@ namespace Draft.Tests
                 };
             }
 
+            public static object ClusterMemberResponse(Uri[] clientUris = null, Uri[] peerUris = null)
+            {
+                return new
+                {
+                    id = Guid.NewGuid().ToString(),
+                    name = Guid.NewGuid().ToString(),
+                    clientURLs = (clientUris ?? new Uri[0]).Select(x => x.ToString()).ToArray(),
+                    peerURLs = (peerUris ?? new Uri[0]).Select(x => x.ToString()).ToArray()
+                };
+            }
+
+            public static object ClusterMembersResponse(params object[] members)
+            {
+                return new
+                {
+                    members = members
+                };
+            }
+
         }
 
     }

--- a/tests/Draft.Tests/Fixtures/Fixtures.Statistics.cs
+++ b/tests/Draft.Tests/Fixtures/Fixtures.Statistics.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Linq;
+
+namespace Draft.Tests
+{
+    internal static partial class Fixtures
+    {
+
+        public static class Statistics
+        {
+
+            public static readonly string LeaderResponse = @"{
+    ""followers"": {
+        ""6e3bd23ae5f1eae0"": {
+            ""counts"": {
+                ""fail"": 0,
+                ""success"": 745
+            },
+            ""latency"": {
+                ""average"": 0.017039507382550306,
+                ""current"": 0.000138,
+                ""maximum"": 1.007649,
+                ""minimum"": 0,
+                ""standardDeviation"": 0.05289178277920594
+            }
+        },
+        ""a8266ecf031671f3"": {
+            ""counts"": {
+                ""fail"": 0,
+                ""success"": 735
+            },
+            ""latency"": {
+                ""average"": 0.012124141496598642,
+                ""current"": 0.000559,
+                ""maximum"": 0.791547,
+                ""minimum"": 0,
+                ""standardDeviation"": 0.04187900156583733
+            }
+        }
+    },
+    ""leader"": ""924e2e83e93f2560""
+}";
+
+            public static readonly string SelfResponse = @"{
+    ""id"": ""eca0338f4ea31566"",
+    ""leaderInfo"": {
+        ""leader"": ""8a69d5f6b7814500"",
+        ""startTime"": ""2014-10-24T13:15:51.186620747-07:00"",
+        ""uptime"": ""10m59.322358947s""
+    },
+    ""name"": ""node3"",
+    ""recvAppendRequestCnt"": 5944,
+    ""recvBandwidthRate"": 570.6254930219969,
+    ""recvPkgRate"": 9.00892789741075,
+    ""sendAppendRequestCnt"": 0,
+    ""startTime"": ""2014-10-24T13:15:50.072007085-07:00"",
+    ""state"": ""StateFollower""
+}";
+
+            public static readonly string StoreResponse = @"{
+    ""compareAndSwapFail"": 0,
+    ""compareAndSwapSuccess"": 0,
+    ""createFail"": 0,
+    ""createSuccess"": 2,
+    ""deleteFail"": 0,
+    ""deleteSuccess"": 0,
+    ""expireCount"": 0,
+    ""getsFail"": 4,
+    ""getsSuccess"": 75,
+    ""setsFail"": 2,
+    ""setsSuccess"": 4,
+    ""updateFail"": 0,
+    ""updateSuccess"": 0,
+    ""watchers"": 0
+}";
+
+        }
+
+    }
+}

--- a/tests/Draft.Tests/Helpers/XmlValueConverter.cs
+++ b/tests/Draft.Tests/Helpers/XmlValueConverter.cs
@@ -1,38 +1,31 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Xml.Serialization;
 
 namespace Draft.Tests
 {
-    public class XmlValueConverter<T> : IKeyDataValueConverter
+    public class XmlValueConverter : IKeyDataValueConverter
     {
 
-        public XmlValueConverter()
-        {
-            XmlSerializer = new XmlSerializer(typeof (T));
-        }
-
-        public XmlSerializer XmlSerializer { get; private set; }
-
-        public object ReadString(string value)
+        public T Read<T>(string value)
         {
             using (var sr = new StringReader(value))
             {
-                return XmlSerializer.Deserialize(sr);
+                var serializer = new XmlSerializer(typeof (T));
+                return (T) serializer.Deserialize(sr);
             }
         }
 
-        public string WriteString(object value)
+        public string Write<T>(T value)
         {
-            var sb = new StringBuilder();
-            using (var sw = new StringWriter(sb))
+            using (var sw = new StringWriter())
             {
-                XmlSerializer.Serialize(sw, value);
+                var serializer = new XmlSerializer(typeof (T));
+                serializer.Serialize(sw, value);
+                sw.Flush();
+                return sw.ToString();
             }
-
-            return sb.ToString();
         }
 
     }

--- a/tests/Draft.Tests/Tests/Cluster/DeleteMemberTests.cs
+++ b/tests/Draft.Tests/Tests/Cluster/DeleteMemberTests.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+using Draft.Exceptions;
+
+using FluentAssertions;
+
+using Flurl;
+using Flurl.Http.Testing;
+
+using Xunit;
+
+namespace Draft.Tests.Cluster
+{
+    public class DeleteMemberTests
+    {
+
+        [Fact]
+        public async Task ShouldCallTheCorrectUrlByAwaitingImmediately()
+        {
+            using (var http = new HttpTest())
+            {
+                http.RespondWithJson(Fixtures.Cluster.CreateResponse(Fixtures.EtcdUrl.ToUri()));
+
+                var memberId = StaticRandom.Instance.Next();
+
+                await Etcd.ClientFor(Fixtures.EtcdUrl.ToUri())
+                          .Cluster
+                          .DeleteMember()
+                          .WithMemberId(memberId.ToString());
+
+                http.Should()
+                    .HaveCalled(
+                        Fixtures.EtcdUrl
+                                .AppendPathSegment(Constants.Etcd.Path_Members)
+                                .AppendPathSegment(memberId.ToString())
+                    )
+                    .WithVerb(HttpMethod.Delete)
+                    .Times(1);
+            }
+        }
+
+        [Fact]
+        public void ShouldThrowBadRequestExceptionOn400ResponseCode()
+        {
+            using (var http = new HttpTest())
+            {
+                http.RespondWith(HttpStatusCode.BadRequest, string.Empty);
+
+                Func<Task> action = async () =>
+                {
+                    await Etcd.ClientFor(Fixtures.EtcdUrl.ToUri())
+                              .Cluster
+                              .DeleteMember()
+                              .WithMemberId(StaticRandom.Instance.Next().ToString());
+                };
+
+                action.ShouldThrowExactly<BadRequestException>()
+                      .And
+                      .IsBadRequest.Should().BeTrue();
+            }
+        }
+
+        [Fact]
+        public void ShouldThrowInvalidRequestExceptionOn404ResponseCode()
+        {
+            using (var http = new HttpTest())
+            {
+                http.RespondWith(HttpStatusCode.NotFound, string.Empty);
+
+                Func<Task> action = async () =>
+                {
+                    await Etcd.ClientFor(Fixtures.EtcdUrl.ToUri())
+                              .Cluster
+                              .DeleteMember()
+                              .WithMemberId(StaticRandom.Instance.Next().ToString());
+                };
+
+                action.ShouldThrowExactly<InvalidRequestException>()
+                      .And
+                      .IsInvalidRequest.Should().BeTrue();
+            }
+        }
+
+    }
+}

--- a/tests/Draft.Tests/Tests/Cluster/GetLeaderTests.cs
+++ b/tests/Draft.Tests/Tests/Cluster/GetLeaderTests.cs
@@ -17,7 +17,7 @@ using Xunit;
 
 namespace Draft.Tests.Cluster
 {
-    public class CreateMemberTests
+    public class GetLeaderTests
     {
 
         [Fact]
@@ -25,25 +25,28 @@ namespace Draft.Tests.Cluster
         {
             using (var http = new HttpTest())
             {
-                http.RespondWithJson(Fixtures.Cluster.CreateResponse(Fixtures.EtcdUrl.ToUri()));
+                http.RespondWithJson(Fixtures.Cluster.ClusterMemberResponse(new[] {Fixtures.EtcdUrl.ToUri()}, new[] {Fixtures.EtcdUrl.ToUri()}));
 
-                var member = await Etcd.ClientFor(Fixtures.EtcdUrl.ToUri())
+                var leader = await Etcd.ClientFor(Fixtures.EtcdUrl.ToUri())
                                        .Cluster
-                                       .CreateMember()
-                                       .WithPeerUri(Fixtures.EtcdUrl.ToUri());
+                                       .GetLeader();
 
                 http.Should()
                     .HaveCalled(
                         Fixtures.EtcdUrl
-                                .AppendPathSegment(Constants.Etcd.Path_Members)
+                                .AppendPathSegment(Constants.Etcd.Path_Members_Leader)
                     )
-                    .WithVerb(HttpMethod.Post)
-                    .WithContentType(Constants.Http.ContentType_ApplicationJson)
+                    .WithVerb(HttpMethod.Get)
                     .Times(1);
 
-                member.Should().NotBeNull();
+                leader.Should().NotBeNull();
 
-                member.PeerUrls.Should()
+                leader.PeerUrls.Should()
+                      .NotBeEmpty()
+                      .And
+                      .ContainSingle(x => Fixtures.EtcdUrl.ToUri().Equals(x));
+
+                leader.ClientUrls.Should()
                       .NotBeEmpty()
                       .And
                       .ContainSingle(x => Fixtures.EtcdUrl.ToUri().Equals(x));
@@ -51,23 +54,22 @@ namespace Draft.Tests.Cluster
         }
 
         [Fact]
-        public void ShouldThrowExistingPeerAddressExceptionOnDuplicatePeerAddress()
+        public void ShouldThrowServiceUnavailableExceptionOn503ResponseCode()
         {
             using (var http = new HttpTest())
             {
-                http.RespondWithJson(HttpStatusCode.Conflict, Fixtures.CreateErrorMessage(Constants.Etcd.ErrorCode_ExistingPeerAddress));
+                http.RespondWith(HttpStatusCode.ServiceUnavailable, string.Empty);
 
                 Func<Task> action = async () =>
                 {
                     await Etcd.ClientFor(Fixtures.EtcdUrl.ToUri())
                               .Cluster
-                              .CreateMember()
-                              .WithPeerUri(Fixtures.EtcdUrl.ToUri());
+                              .GetLeader();
                 };
 
-                action.ShouldThrowExactly<ExistingPeerAddressException>()
+                action.ShouldThrowExactly<ServiceUnavailableException>()
                       .And
-                      .IsExistingPeerAddress.Should().BeTrue();
+                      .IsServiceUnavailable.Should().BeTrue();
             }
         }
 

--- a/tests/Draft.Tests/Tests/Cluster/GetMembersTests.cs
+++ b/tests/Draft.Tests/Tests/Cluster/GetMembersTests.cs
@@ -1,0 +1,53 @@
+﻿using System;
+
+using Flurl;
+
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+using Flurl.Http.Testing;
+
+using Xunit;
+
+namespace Draft.Tests.Cluster
+{
+    public class GetMembersTests
+    {
+
+        [Fact]
+        public async Task ShouldCallTheCorrectUrlByAwaitingImmediately()
+        {
+            using (var http = new HttpTest())
+            {
+                http.RespondWithJson(
+                    Fixtures.Cluster.ClusterMembersResponse(
+                        Fixtures.Cluster.ClusterMemberResponse(),
+                        Fixtures.Cluster.ClusterMemberResponse(),
+                        Fixtures.Cluster.ClusterMemberResponse(),
+                        Fixtures.Cluster.ClusterMemberResponse(),
+                        Fixtures.Cluster.ClusterMemberResponse()
+                        ));
+
+                var members = await Etcd.ClientFor(Fixtures.EtcdUrl.ToUri())
+                                        .Cluster
+                                        .GetMembers();
+
+                http.Should()
+                    .HaveCalled(
+                        Fixtures.EtcdUrl
+                                .AppendPathSegment(Constants.Etcd.Path_Members)
+                    )
+                    .WithVerb(HttpMethod.Get)
+                    .Times(1);
+
+                members.Should().NotBeNull()
+                       .And
+                       .HaveCount(5);
+            }
+        }
+
+    }
+}

--- a/tests/Draft.Tests/Tests/Cluster/UpdateMemberPeerUrlsTests.cs
+++ b/tests/Draft.Tests/Tests/Cluster/UpdateMemberPeerUrlsTests.cs
@@ -1,0 +1,64 @@
+﻿using System;
+
+using Flurl;
+
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+using Flurl.Http.Testing;
+
+using Xunit;
+
+namespace Draft.Tests.Cluster
+{
+    public class UpdateMemberPeerUrlsTests
+    {
+
+        [Fact]
+        public async Task ShouldCallTheCorrectUrlByAwaitingImmediately()
+        {
+            using (var http = new HttpTest())
+            {
+                http.RespondWithJson(
+                    Fixtures.Cluster.ClusterMemberResponse(
+                        peerUris : new[]
+                        {
+                            Fixtures.EtcdUrl.ToUri(),
+                            Fixtures.EtcdUrl.ToUri()
+                        }));
+
+                var memberId = StaticRandom.Instance.Next().ToString();
+
+                var member = await Etcd.ClientFor(Fixtures.EtcdUrl.ToUri())
+                                       .Cluster
+                                       .UpdateMemberPeerUrls()
+                                       .WithMemberId(memberId)
+                                       .WithPeerUri(Fixtures.EtcdUrl.ToUri(), Fixtures.EtcdUrl.ToUri());
+
+                http.Should()
+                    .HaveCalled(
+                        Fixtures.EtcdUrl
+                                .AppendPathSegment(Constants.Etcd.Path_Members)
+                                .AppendPathSegment(memberId)
+                    )
+                    .WithVerb(HttpMethod.Put)
+                    .WithContentType(Constants.Http.ContentType_ApplicationJson)
+                    .Times(1);
+
+                member.Should().NotBeNull();
+                member.PeerUrls
+                      .Should()
+                      .HaveCount(2)
+                      .And
+                      .ContainInOrder(
+                          Fixtures.EtcdUrl.ToUri(),
+                          Fixtures.EtcdUrl.ToUri()
+                    );
+            }
+        }
+
+    }
+}

--- a/tests/Draft.Tests/Tests/Statistics/GetLeaderTests.cs
+++ b/tests/Draft.Tests/Tests/Statistics/GetLeaderTests.cs
@@ -1,0 +1,48 @@
+﻿using System;
+
+using FluentAssertions;
+
+using Flurl;
+
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+using Flurl.Http.Testing;
+
+using Xunit;
+
+namespace Draft.Tests.Statistics
+{
+    public class GetLeaderTests
+    {
+
+        [Fact]
+        public async Task ShouldCallTheCorrectUrlByAwaitingImmediately()
+        {
+            using (var http = new HttpTest())
+            {
+                http.RespondWith(Fixtures.Statistics.LeaderResponse);
+
+                var response = await Etcd.ClientFor(Fixtures.EtcdUrl.ToUri())
+                    .Statistics
+                    .GetLeaderStatistics();
+
+                http.Should()
+                    .HaveCalled(Fixtures.EtcdUrl.AppendPathSegment(Constants.Etcd.Path_Stats_Leader))
+                    .WithVerb(HttpMethod.Get)
+                    .Times(1);
+
+                response.Should().NotBeNull();
+
+                response.Leader.Should().NotBeNullOrWhiteSpace();
+                response.Followers.Should().NotBeNull()
+                    .And.HaveCount(2);
+                response.Followers.Keys.OrderBy(x => x).Should()
+                    .HaveCount(2)
+                    .And.ContainInOrder("6e3bd23ae5f1eae0", "a8266ecf031671f3");
+            }
+        }
+
+    }
+}

--- a/tests/Draft.Tests/Tests/Statistics/GetSelfTests.cs
+++ b/tests/Draft.Tests/Tests/Statistics/GetSelfTests.cs
@@ -1,0 +1,52 @@
+﻿using System;
+
+using FluentAssertions;
+
+using Flurl;
+
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+using Draft.Responses.Statistics;
+
+using Flurl.Http.Testing;
+
+using Xunit;
+
+namespace Draft.Tests.Statistics
+{
+    public class GetSelfTests
+    {
+
+        [Fact]
+        public async Task ShouldCallTheCorrectUrlByAwaitingImmediately()
+        {
+            using (var http = new HttpTest())
+            {
+                http.RespondWith(Fixtures.Statistics.SelfResponse);
+
+                var response = await Etcd.ClientFor(Fixtures.EtcdUrl.ToUri())
+                    .Statistics
+                    .GetServerStatistics();
+
+                http.Should()
+                    .HaveCalled(Fixtures.EtcdUrl.AppendPathSegment(Constants.Etcd.Path_Stats_Self))
+                    .WithVerb(HttpMethod.Get)
+                    .Times(1);
+
+                response.Should().NotBeNull();
+                response.Id.Should().NotBeNullOrWhiteSpace();
+                response.Name.Should().NotBeNullOrWhiteSpace();
+
+                response.LeaderInfo.Should().NotBeNull();
+                response.LeaderInfo.Leader.Should().Be("8a69d5f6b7814500");
+                response.LeaderInfo.StartTime.Should().HaveValue().And.NotBe(default(DateTime));
+                response.LeaderInfo.Uptime.Should().NotBeNullOrWhiteSpace();
+
+                response.State.Should().Be(StateType.StateFollower);
+            }
+        }
+
+    }
+}

--- a/tests/Draft.Tests/Tests/Statistics/GetStoreTests.cs
+++ b/tests/Draft.Tests/Tests/Statistics/GetStoreTests.cs
@@ -1,0 +1,54 @@
+﻿using System;
+
+using FluentAssertions;
+
+using Flurl;
+
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+using Flurl.Http.Testing;
+
+using Xunit;
+
+namespace Draft.Tests.Statistics
+{
+    public class GetStoreTests
+    {
+
+        [Fact]
+        public async Task ShouldCallTheCorrectUrlByAwaitingImmediately()
+        {
+            using (var http = new HttpTest())
+            {
+                http.RespondWith(Fixtures.Statistics.StoreResponse);
+
+                var response = await Etcd.ClientFor(Fixtures.EtcdUrl.ToUri())
+                    .Statistics
+                    .GetStoreStatistics();
+
+                http.Should()
+                    .HaveCalled(Fixtures.EtcdUrl.AppendPathSegment(Constants.Etcd.Path_Stats_Store))
+                    .WithVerb(HttpMethod.Get)
+                    .Times(1);
+
+                response.Should().NotBeNull();
+                response.CreateSuccess.Should().Be(2);
+                response.GetsFail.Should().Be(4);
+                response.GetsSuccess.Should().Be(75);
+                response.SetsFail.Should().Be(2);
+                response.SetsSuccess.Should().Be(4);
+                response.CompareAndDeleteFail.Should().Be(0);
+                response.CompareAndDeleteSuccess.Should().Be(0);
+                response.CompareAndSwapFail.Should().Be(0);
+                response.CompareAndSwapSuccess.Should().Be(0);
+                response.DeleteSuccess.Should().Be(0);
+                response.DeleteFail.Should().Be(0);
+                response.ExpireCount.Should().Be(0);
+                response.Watchers.Should().Be(0);
+            }
+        }
+
+    }
+}

--- a/tests/Draft.Tests/Tests/ValueConverterTests.cs
+++ b/tests/Draft.Tests/Tests/ValueConverterTests.cs
@@ -11,7 +11,6 @@ using System.Threading.Tasks;
 using Flurl.Http.Testing;
 
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 using Xunit;
 
@@ -24,8 +23,8 @@ namespace Draft.Tests
         public async Task Get_ShouldUseConfiguredValueConverter()
         {
             var dto = Fixtures.Dto.SimpleDataContract();
-            var converter = new XmlValueConverter<SimpleDataContractDto>();
-            var expected = converter.WriteString(dto);
+            var converter = new XmlValueConverter();
+            var expected = converter.Write(dto);
 
             using (var http = new HttpTest())
             {
@@ -65,8 +64,8 @@ namespace Draft.Tests
         public async Task Get_ShouldUsePassedValueConverter()
         {
             var dto = Fixtures.Dto.SimpleDataContract();
-            var converter = new XmlValueConverter<SimpleDataContractDto>();
-            var expected = converter.WriteString(dto);
+            var converter = new XmlValueConverter();
+            var expected = converter.Write(dto);
 
             using (var http = new HttpTest())
             {
@@ -100,25 +99,9 @@ namespace Draft.Tests
         }
 
         [Fact]
-        public void JsonConverter_ShouldDeserializeDynamicCorrectly()
-        {
-            var result = Converters.Json.ReadString(Fixtures.Dto.Json_SimpleDataContract);
-
-            result.Should().NotBeNull();
-            result.Should().BeAssignableTo<JObject>();
-
-            var jresult = (JObject) result;
-
-            jresult.HasValues.Should().BeTrue();
-
-            jresult.Property("id").Should().NotBeNullOrEmpty();
-            jresult.Property("NAME").Should().NotBeNullOrEmpty();
-        }
-
-        [Fact]
         public void JsonConverter_ShouldDeserializeTypeCorrectly()
         {
-            var result = Converters.Json.ReadString<SimpleDataContractDto>(Fixtures.Dto.Json_SimpleDataContract);
+            var result = Converters.Json.Read<SimpleDataContractDto>(Fixtures.Dto.Json_SimpleDataContract);
 
             result.Should().NotBeNull();
 
@@ -130,7 +113,7 @@ namespace Draft.Tests
         [Fact]
         public void StringConverter_ShouldDeserializeCorrectly()
         {
-            var result = Converters.String.ReadString(Fixtures.Dto.Json_SimpleDataContract_Name);
+            var result = Converters.String.Read<string>(Fixtures.Dto.Json_SimpleDataContract_Name);
 
             result.Should().NotBeNull();
             result.Should().Be(Fixtures.Dto.Json_SimpleDataContract_Name);
@@ -139,7 +122,7 @@ namespace Draft.Tests
         [Fact]
         public void StringConverter_ShouldDoNothingWithStringParameterOnWriteStringMethod()
         {
-            var result = Converters.String.WriteString(Fixtures.Dto.Json_SimpleDataContract_Name);
+            var result = Converters.String.Write(Fixtures.Dto.Json_SimpleDataContract_Name);
 
             result.Should().NotBeNull();
             result.Should().Be(Fixtures.Dto.Json_SimpleDataContract_Name);
@@ -203,8 +186,8 @@ namespace Draft.Tests
         public async Task Upsert_ShouldUsedPassedValueConverter()
         {
             var dto = Fixtures.Dto.SimpleDataContract();
-            var converter = new XmlValueConverter<SimpleDataContractDto>();
-            var expected = converter.WriteString(dto);
+            var converter = new XmlValueConverter();
+            var expected = converter.Write(dto);
 
             using (var http = new HttpTest())
             {

--- a/tests/Draft.Tests/packages.Draft-Net45.Tests.config
+++ b/tests/Draft.Tests/packages.Draft-Net45.Tests.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AutoFixture" version="3.30.3" targetFramework="net45" />
-  <package id="FluentAssertions" version="3.3.0" targetFramework="net45" />
-  <package id="Flurl" version="1.0.7" targetFramework="net45" />
-  <package id="Flurl.Http" version="0.6.0" targetFramework="net45" />
+  <package id="AutoFixture" version="3.30.8" targetFramework="net45" />
+  <package id="FluentAssertions" version="3.4.1" targetFramework="net45" />
+  <package id="Flurl" version="1.0.8" targetFramework="net45" />
+  <package id="Flurl.Http" version="0.6.2" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="net45" />


### PR DESCRIPTION
* New: `EndpointVerificationStrategy.ClusterMembers` - Similar verification as `EndpointVerificationStrategy.Any` but also adds verified cluster members to the `EndpointPool`.
* New: `IEtcdClient.Statistics`
	* `GetLeaderStatistics` - Retrieve the statistical information for leader of the etcd cluster
	* `GetServerStatistics` - Retrieve the statistical information for the server (Which server depends on how the `EndpointPool` was built)
	* `GetStoreStatistics` - Retrieve the etcd backing store statistics (For which server depends on how the `EndpointPool` was built)
* Breaking Change: `IEtcdClient.Enqueue` has been moved to `IEtcdClient.Atomic.Enqueue`
* Breaking Change: `IKeyDataValueConverter` overhaul
	* `object ReadString(string value)` has been refactored into `T Read<T>(string value)`
	* `string WriteString(object value)` has been refactored into `string Write<T>(T value)`
* Change: The following have been annotated with `[Serializable]`
	* `Endpoint`
	* `EndpointPool`
	* `EndpointRoutingStrategy`
	* `EndpointVerificationStrategy`