### PR TITLE
A bunch of random hacking

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,7 @@
+### new in 1.0.7
+* New: EndpointPool.Build()..WithHttpReadTimeout() - Set timeout for HTTP GET requests
+* Fixed: NullReferenceException thrown in certain HTTP timeout conditions is now EtcdTimeoutException
+
 ### new in 1.0.6.1 (Release 2018/08/02)
 * Change: Updated `build.cake` to support deploying symbol package
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,4 +1,4 @@
-### new in 1.0.7
+### new in 1.0.7 (Release 2018/08/09)
 * New: EndpointPool.Build()..WithHttpReadTimeout() - Set timeout for HTTP GET requests
 * Fixed: NullReferenceException thrown in certain HTTP timeout conditions is now EtcdTimeoutException
 

--- a/source/Draft/Endpoints/EndpointPool.Builder.cs
+++ b/source/Draft/Endpoints/EndpointPool.Builder.cs
@@ -27,15 +27,13 @@ namespace Draft.Endpoints
 
             private EndpointVerificationStrategy _verificationStrategy;
 
-            internal EndpointRoutingStrategy RoutingStrategy
-            {
-                get { return _routingStrategy ?? EndpointRoutingStrategy.Default; }
-            }
+            private TimeSpan? _httpGetTimeout;
 
-            internal EndpointVerificationStrategy VerificationStrategy
-            {
-                get { return _verificationStrategy ?? EndpointVerificationStrategy.Default; }
-            }
+            private EndpointRoutingStrategy RoutingStrategy => _routingStrategy ?? EndpointRoutingStrategy.Default;
+
+            private EndpointVerificationStrategy VerificationStrategy => _verificationStrategy ?? EndpointVerificationStrategy.Default;
+
+            internal TimeSpan? HttpGetTimeout => _httpGetTimeout;
 
             /// <summary>
             ///     Verifies the passed <paramref name="uris" /> first to ensure that they are <see cref="Uri.IsAbsoluteUri" />. Then
@@ -54,19 +52,22 @@ namespace Draft.Endpoints
             {
                 if (uris == null || !uris.Any())
                 {
-                    throw new ArgumentNullException("uris", "You must supply at least 1 Uri");
+                    throw new ArgumentNullException(nameof(uris), "You must supply at least 1 Uri");
                 }
                 var invalidUris = uris.Where(x => !x.IsAbsoluteUri).ToList();
                 if (invalidUris.Any())
                 {
                     throw new ArgumentException(
-                        string.Format("The following Uri(s) are not valid absolute Uri(s): '{0}'", string.Join(", ", invalidUris)),
-                        "uris"
+                        $"The following Uri(s) are not valid absolute Uri(s): '{string.Join(", ", invalidUris)}'",
+                        nameof(uris)
                         );
                 }
                 var endpoints = await VerificationStrategy.Verify(uris);
 
-                return new EndpointPool(endpoints, RoutingStrategy);
+                return new EndpointPool(endpoints, RoutingStrategy)
+                {
+                    HttpGetTimeout = _httpGetTimeout
+                };
             }
 
             /// <summary>
@@ -77,7 +78,7 @@ namespace Draft.Endpoints
             {
                 if (routingStrategy == null)
                 {
-                    throw new ArgumentNullException("routingStrategy");
+                    throw new ArgumentNullException(nameof(routingStrategy));
                 }
                 _routingStrategy = routingStrategy;
                 return this;
@@ -91,9 +92,24 @@ namespace Draft.Endpoints
             {
                 if (verificationStrategy == null)
                 {
-                    throw new ArgumentNullException("verificationStrategy");
+                    throw new ArgumentNullException(nameof(verificationStrategy));
                 }
                 _verificationStrategy = verificationStrategy;
+                return this;
+            }
+
+            /// <summary>
+            ///     Sets the default timeout for HTTP GET requests
+            /// </summary>
+            /// <param name="httpGetTimeout"></param>
+            /// <returns></returns>
+            public Builder WithHttpReadTimeout(TimeSpan httpGetTimeout)
+            {
+                if (httpGetTimeout == null)
+                {
+                    throw new ArgumentNullException(nameof(httpGetTimeout));
+                }
+                _httpGetTimeout = httpGetTimeout;
                 return this;
             }
 

--- a/source/Draft/Endpoints/EndpointPool.cs
+++ b/source/Draft/Endpoints/EndpointPool.cs
@@ -38,5 +38,8 @@ namespace Draft.Endpoints
             return pathSegment.ToUrl(RoutingStrategy.Select(pathSegment.Value, OnlineEndpoints).Uri);
         }
 
+        [IgnoreDataMember]
+        internal TimeSpan? HttpGetTimeout { get; set; } = null;
+
     }
 }

--- a/source/Draft/Exceptions/ExceptionHandling.cs
+++ b/source/Draft/Exceptions/ExceptionHandling.cs
@@ -36,6 +36,8 @@ namespace Draft
 
             var etcdError = This.GetResponseJson<EtcdError>();
 
+            if (etcdError == null) { return new UnknownErrorException(This.Message); }
+
             var message = etcdError.Message;
 
             etcdError.ErrorCode = etcdError.ErrorCode
@@ -254,7 +256,9 @@ namespace Draft
 
         private static bool IsTimeoutException(this FlurlHttpException This)
         {
-            return This is FlurlHttpTimeoutException;
+            if (This is FlurlHttpTimeoutException) return true;
+
+            return This.InnerException is OperationCanceledException;
         }
 
         #endregion

--- a/source/Draft/Extensions/Flurl.Extensions.cs
+++ b/source/Draft/Extensions/Flurl.Extensions.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 
 using Flurl;
+using Flurl.Http;
 
 namespace Draft
 {
@@ -18,6 +19,11 @@ namespace Draft
         public static Url Conditionally(this Url This, bool predicate, Func<Url, Url> action)
         {
             return predicate ? action(This) : This;
+        }
+
+        public static IFlurlClient Conditionally(this Url This, bool predicate, Func<Url, IFlurlClient> action)
+        {
+            return predicate ? action(This) : new FlurlClient(This, true);
         }
 
         public static Task<HttpResponseMessage> Conditionally(this Url This, bool predicate, object data, Func<Url, object, Task<HttpResponseMessage>> ifTrue, Func<Url, object, Task<HttpResponseMessage>> ifFalse)

--- a/source/Draft/Requests/BaseRequest.cs
+++ b/source/Draft/Requests/BaseRequest.cs
@@ -31,5 +31,6 @@ namespace Draft.Requests
             }
         }
 
+        protected TimeSpan? HttpGetTimeout => _endpointPool.HttpGetTimeout;
     }
 }

--- a/source/Draft/Requests/GetRequest.cs
+++ b/source/Draft/Requests/GetRequest.cs
@@ -28,6 +28,7 @@ namespace Draft.Requests
                 return await TargetUrl
                     .Conditionally(Quorum.HasValue && Quorum.Value, x => x.SetQueryParam(Constants.Etcd.Parameter_Quorum, Constants.Etcd.Parameter_True))
                     .Conditionally(Recursive.HasValue && Recursive.Value, x => x.SetQueryParam(Constants.Etcd.Parameter_Recursive, Constants.Etcd.Parameter_True))
+                    .Conditionally(HttpGetTimeout != null, x=>x.WithTimeout(HttpGetTimeout.GetValueOrDefault()))
                     .GetAsync()
                     .ReceiveEtcdResponse<KeyEvent>(EtcdClient);
             }


### PR DESCRIPTION
I observed that when my etcd node had lost consensus (all other nodes in the etcd cluster are offline), the client behaves badly in two ways:

1. Attempting to get a key threw an unexpected NullReferenceException.
2. The get request took an unusually long time to throw the exception

This resolves those.