### PR TITLE
Don't reset global flurl settings in unit tests

### DIFF
--- a/tests/Draft.Tests/Tests/VerificationStrategies/BaseVerificationStrategyTests.cs
+++ b/tests/Draft.Tests/Tests/VerificationStrategies/BaseVerificationStrategyTests.cs
@@ -37,7 +37,7 @@ namespace Draft.Tests.VerificationStrategies
 
         public void Dispose()
         {
-            ResetInvalidHostHelper();
+
         }
 
         protected EndpointPool.Builder CreateSut(EndpointVerificationStrategy strategy = null)
@@ -50,11 +50,5 @@ namespace Draft.Tests.VerificationStrategies
         {
             return new HttpTest().Configure(x => { x.HttpClientFactory = new TestingHttpClientFactory(responseFactory); });
         }
-
-        protected void ResetInvalidHostHelper()
-        {
-            FlurlHttp.GlobalSettings.ResetDefaults();
-        }
-
     }
 }


### PR DESCRIPTION
This causes unit tests to fail intermittently with a NullReferenceException due to a thread-safety concern in Flurl. It also doesn't appear to be necessary. The unit tests deriving from this class pass without it and none of the tests themselves currently modify the static global settings (and if they did it would be a separate threading issue with the other tests, so they probably never will)